### PR TITLE
Replaces sass append with list.append to remove deprecation warnings.

### DIFF
--- a/fonts/google/abeezee/scss/mixins.scss
+++ b/fonts/google/abeezee/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/abel/scss/mixins.scss
+++ b/fonts/google/abel/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/abhaya-libre/scss/mixins.scss
+++ b/fonts/google/abhaya-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/aboreto/scss/mixins.scss
+++ b/fonts/google/aboreto/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/abril-fatface/scss/mixins.scss
+++ b/fonts/google/abril-fatface/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/abyssinica-sil/scss/mixins.scss
+++ b/fonts/google/abyssinica-sil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/aclonica/scss/mixins.scss
+++ b/fonts/google/aclonica/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/acme/scss/mixins.scss
+++ b/fonts/google/acme/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/actor/scss/mixins.scss
+++ b/fonts/google/actor/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/adamina/scss/mixins.scss
+++ b/fonts/google/adamina/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/adlam-display/scss/mixins.scss
+++ b/fonts/google/adlam-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/advent-pro/scss/mixins.scss
+++ b/fonts/google/advent-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/afacad-flux/scss/mixins.scss
+++ b/fonts/google/afacad-flux/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/afacad/scss/mixins.scss
+++ b/fonts/google/afacad/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/agbalumo/scss/mixins.scss
+++ b/fonts/google/agbalumo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/agdasima/scss/mixins.scss
+++ b/fonts/google/agdasima/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/agu-display/scss/mixins.scss
+++ b/fonts/google/agu-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/aguafina-script/scss/mixins.scss
+++ b/fonts/google/aguafina-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/akatab/scss/mixins.scss
+++ b/fonts/google/akatab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/akaya-kanadaka/scss/mixins.scss
+++ b/fonts/google/akaya-kanadaka/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/akaya-telivigala/scss/mixins.scss
+++ b/fonts/google/akaya-telivigala/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/akronim/scss/mixins.scss
+++ b/fonts/google/akronim/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/akshar/scss/mixins.scss
+++ b/fonts/google/akshar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/aladin/scss/mixins.scss
+++ b/fonts/google/aladin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alata/scss/mixins.scss
+++ b/fonts/google/alata/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alatsi/scss/mixins.scss
+++ b/fonts/google/alatsi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/albert-sans/scss/mixins.scss
+++ b/fonts/google/albert-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/aldrich/scss/mixins.scss
+++ b/fonts/google/aldrich/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alef/scss/mixins.scss
+++ b/fonts/google/alef/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alegreya-sans-sc/scss/mixins.scss
+++ b/fonts/google/alegreya-sans-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alegreya-sans/scss/mixins.scss
+++ b/fonts/google/alegreya-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alegreya-sc/scss/mixins.scss
+++ b/fonts/google/alegreya-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alegreya/scss/mixins.scss
+++ b/fonts/google/alegreya/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/aleo/scss/mixins.scss
+++ b/fonts/google/aleo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alex-brush/scss/mixins.scss
+++ b/fonts/google/alex-brush/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alexandria/scss/mixins.scss
+++ b/fonts/google/alexandria/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alfa-slab-one/scss/mixins.scss
+++ b/fonts/google/alfa-slab-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alice/scss/mixins.scss
+++ b/fonts/google/alice/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alike-angular/scss/mixins.scss
+++ b/fonts/google/alike-angular/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alike/scss/mixins.scss
+++ b/fonts/google/alike/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alkalami/scss/mixins.scss
+++ b/fonts/google/alkalami/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alkatra/scss/mixins.scss
+++ b/fonts/google/alkatra/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/allan/scss/mixins.scss
+++ b/fonts/google/allan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/allerta-stencil/scss/mixins.scss
+++ b/fonts/google/allerta-stencil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/allerta/scss/mixins.scss
+++ b/fonts/google/allerta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/allison/scss/mixins.scss
+++ b/fonts/google/allison/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/allura/scss/mixins.scss
+++ b/fonts/google/allura/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/almarai/scss/mixins.scss
+++ b/fonts/google/almarai/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/almendra-display/scss/mixins.scss
+++ b/fonts/google/almendra-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/almendra-sc/scss/mixins.scss
+++ b/fonts/google/almendra-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/almendra/scss/mixins.scss
+++ b/fonts/google/almendra/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alumni-sans-collegiate-one/scss/mixins.scss
+++ b/fonts/google/alumni-sans-collegiate-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alumni-sans-inline-one/scss/mixins.scss
+++ b/fonts/google/alumni-sans-inline-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alumni-sans-pinstripe/scss/mixins.scss
+++ b/fonts/google/alumni-sans-pinstripe/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/alumni-sans/scss/mixins.scss
+++ b/fonts/google/alumni-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/amarante/scss/mixins.scss
+++ b/fonts/google/amarante/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/amaranth/scss/mixins.scss
+++ b/fonts/google/amaranth/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/amatic-sc/scss/mixins.scss
+++ b/fonts/google/amatic-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/amethysta/scss/mixins.scss
+++ b/fonts/google/amethysta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/amiko/scss/mixins.scss
+++ b/fonts/google/amiko/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/amiri-quran/scss/mixins.scss
+++ b/fonts/google/amiri-quran/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/amiri/scss/mixins.scss
+++ b/fonts/google/amiri/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/amita/scss/mixins.scss
+++ b/fonts/google/amita/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anaheim/scss/mixins.scss
+++ b/fonts/google/anaheim/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/andada-pro/scss/mixins.scss
+++ b/fonts/google/andada-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/andika/scss/mixins.scss
+++ b/fonts/google/andika/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anek-bangla/scss/mixins.scss
+++ b/fonts/google/anek-bangla/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anek-devanagari/scss/mixins.scss
+++ b/fonts/google/anek-devanagari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anek-gujarati/scss/mixins.scss
+++ b/fonts/google/anek-gujarati/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anek-gurmukhi/scss/mixins.scss
+++ b/fonts/google/anek-gurmukhi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anek-kannada/scss/mixins.scss
+++ b/fonts/google/anek-kannada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anek-latin/scss/mixins.scss
+++ b/fonts/google/anek-latin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anek-malayalam/scss/mixins.scss
+++ b/fonts/google/anek-malayalam/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anek-odia/scss/mixins.scss
+++ b/fonts/google/anek-odia/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anek-tamil/scss/mixins.scss
+++ b/fonts/google/anek-tamil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anek-telugu/scss/mixins.scss
+++ b/fonts/google/anek-telugu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/angkor/scss/mixins.scss
+++ b/fonts/google/angkor/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/annapurna-sil/scss/mixins.scss
+++ b/fonts/google/annapurna-sil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/annie-use-your-telescope/scss/mixins.scss
+++ b/fonts/google/annie-use-your-telescope/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anonymous-pro/scss/mixins.scss
+++ b/fonts/google/anonymous-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anta/scss/mixins.scss
+++ b/fonts/google/anta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/antic-didone/scss/mixins.scss
+++ b/fonts/google/antic-didone/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/antic-slab/scss/mixins.scss
+++ b/fonts/google/antic-slab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/antic/scss/mixins.scss
+++ b/fonts/google/antic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anton-sc/scss/mixins.scss
+++ b/fonts/google/anton-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anton/scss/mixins.scss
+++ b/fonts/google/anton/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/antonio/scss/mixins.scss
+++ b/fonts/google/antonio/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anuphan/scss/mixins.scss
+++ b/fonts/google/anuphan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/anybody/scss/mixins.scss
+++ b/fonts/google/anybody/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/aoboshi-one/scss/mixins.scss
+++ b/fonts/google/aoboshi-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ar-one-sans/scss/mixins.scss
+++ b/fonts/google/ar-one-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/arapey/scss/mixins.scss
+++ b/fonts/google/arapey/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/arbutus-slab/scss/mixins.scss
+++ b/fonts/google/arbutus-slab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/arbutus/scss/mixins.scss
+++ b/fonts/google/arbutus/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/architects-daughter/scss/mixins.scss
+++ b/fonts/google/architects-daughter/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/archivo-black/scss/mixins.scss
+++ b/fonts/google/archivo-black/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/archivo-narrow/scss/mixins.scss
+++ b/fonts/google/archivo-narrow/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/archivo/scss/mixins.scss
+++ b/fonts/google/archivo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/are-you-serious/scss/mixins.scss
+++ b/fonts/google/are-you-serious/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/aref-ruqaa-ink/scss/mixins.scss
+++ b/fonts/google/aref-ruqaa-ink/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/aref-ruqaa/scss/mixins.scss
+++ b/fonts/google/aref-ruqaa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/arima-madurai/scss/mixins.scss
+++ b/fonts/google/arima-madurai/scss/mixins.scss
@@ -84,7 +84,7 @@ $axes: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),
@@ -114,18 +114,18 @@ $axes: null !default;
 
                 font-family: string.quote($family),
                 font-style: if(
-                  ($axis == full or $axis == slnt) and map.has-key($metadata, axes, slnt), 
+                  ($axis == full or $axis == slnt) and map.has-key($metadata, axes, slnt),
                   oblique map.get($metadata, axes, slnt, min) + deg map.get($metadata, axes, slnt, max) + deg,
                   $style
                 ),
                 font-display: if($displayVar, var(--fontsource-display, $display), $display),
                 font-weight: if(
-                  ($axis == full or $axis == wght) and map.has-key($metadata, axes, wght), 
+                  ($axis == full or $axis == wght) and map.has-key($metadata, axes, wght),
                   map.get($metadata, axes, wght, min) map.get($metadata, axes, wght, max),
                   $weight
                 ),
                 font-stretch: if(
-                  ($axis == full or $axis == wdth) and map.has-key($metadata, axes, wdth), 
+                  ($axis == full or $axis == wdth) and map.has-key($metadata, axes, wdth),
                   '#{map.get($metadata, axes, wdth, min)}% #{map.get($metadata, axes, wdth, max)}%',
                   null
                 ),

--- a/fonts/google/arima/scss/mixins.scss
+++ b/fonts/google/arima/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/arimo/scss/mixins.scss
+++ b/fonts/google/arimo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/arizonia/scss/mixins.scss
+++ b/fonts/google/arizonia/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/armata/scss/mixins.scss
+++ b/fonts/google/armata/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/arsenal-sc/scss/mixins.scss
+++ b/fonts/google/arsenal-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/arsenal/scss/mixins.scss
+++ b/fonts/google/arsenal/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/artifika/scss/mixins.scss
+++ b/fonts/google/artifika/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/arvo/scss/mixins.scss
+++ b/fonts/google/arvo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/arya/scss/mixins.scss
+++ b/fonts/google/arya/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/asap-condensed/scss/mixins.scss
+++ b/fonts/google/asap-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/asap/scss/mixins.scss
+++ b/fonts/google/asap/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/asar/scss/mixins.scss
+++ b/fonts/google/asar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/asset/scss/mixins.scss
+++ b/fonts/google/asset/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/assistant/scss/mixins.scss
+++ b/fonts/google/assistant/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/astloch/scss/mixins.scss
+++ b/fonts/google/astloch/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/asul/scss/mixins.scss
+++ b/fonts/google/asul/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/athiti/scss/mixins.scss
+++ b/fonts/google/athiti/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/atkinson-hyperlegible/scss/mixins.scss
+++ b/fonts/google/atkinson-hyperlegible/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/atma/scss/mixins.scss
+++ b/fonts/google/atma/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/atomic-age/scss/mixins.scss
+++ b/fonts/google/atomic-age/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/aubrey/scss/mixins.scss
+++ b/fonts/google/aubrey/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/audiowide/scss/mixins.scss
+++ b/fonts/google/audiowide/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/autour-one/scss/mixins.scss
+++ b/fonts/google/autour-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/average-sans/scss/mixins.scss
+++ b/fonts/google/average-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/average/scss/mixins.scss
+++ b/fonts/google/average/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/averia-gruesa-libre/scss/mixins.scss
+++ b/fonts/google/averia-gruesa-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/averia-libre/scss/mixins.scss
+++ b/fonts/google/averia-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/averia-sans-libre/scss/mixins.scss
+++ b/fonts/google/averia-sans-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/averia-serif-libre/scss/mixins.scss
+++ b/fonts/google/averia-serif-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/azeret-mono/scss/mixins.scss
+++ b/fonts/google/azeret-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/b612-mono/scss/mixins.scss
+++ b/fonts/google/b612-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/b612/scss/mixins.scss
+++ b/fonts/google/b612/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/babylonica/scss/mixins.scss
+++ b/fonts/google/babylonica/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bacasime-antique/scss/mixins.scss
+++ b/fonts/google/bacasime-antique/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bad-script/scss/mixins.scss
+++ b/fonts/google/bad-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/badeen-display/scss/mixins.scss
+++ b/fonts/google/badeen-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bagel-fat-one/scss/mixins.scss
+++ b/fonts/google/bagel-fat-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bahiana/scss/mixins.scss
+++ b/fonts/google/bahiana/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bahianita/scss/mixins.scss
+++ b/fonts/google/bahianita/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bai-jamjuree/scss/mixins.scss
+++ b/fonts/google/bai-jamjuree/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bakbak-one/scss/mixins.scss
+++ b/fonts/google/bakbak-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ballet/scss/mixins.scss
+++ b/fonts/google/ballet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/baloo-2/scss/mixins.scss
+++ b/fonts/google/baloo-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/baloo-bhai-2/scss/mixins.scss
+++ b/fonts/google/baloo-bhai-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/baloo-bhaijaan-2/scss/mixins.scss
+++ b/fonts/google/baloo-bhaijaan-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/baloo-bhaina-2/scss/mixins.scss
+++ b/fonts/google/baloo-bhaina-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/baloo-chettan-2/scss/mixins.scss
+++ b/fonts/google/baloo-chettan-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/baloo-da-2/scss/mixins.scss
+++ b/fonts/google/baloo-da-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/baloo-paaji-2/scss/mixins.scss
+++ b/fonts/google/baloo-paaji-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/baloo-tamma-2/scss/mixins.scss
+++ b/fonts/google/baloo-tamma-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/baloo-tammudu-2/scss/mixins.scss
+++ b/fonts/google/baloo-tammudu-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/baloo-thambi-2/scss/mixins.scss
+++ b/fonts/google/baloo-thambi-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/balsamiq-sans/scss/mixins.scss
+++ b/fonts/google/balsamiq-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/balthazar/scss/mixins.scss
+++ b/fonts/google/balthazar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bangers/scss/mixins.scss
+++ b/fonts/google/bangers/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/barlow-condensed/scss/mixins.scss
+++ b/fonts/google/barlow-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/barlow-semi-condensed/scss/mixins.scss
+++ b/fonts/google/barlow-semi-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/barlow/scss/mixins.scss
+++ b/fonts/google/barlow/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/barriecito/scss/mixins.scss
+++ b/fonts/google/barriecito/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/barrio/scss/mixins.scss
+++ b/fonts/google/barrio/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/basic/scss/mixins.scss
+++ b/fonts/google/basic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/baskervville-sc/scss/mixins.scss
+++ b/fonts/google/baskervville-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/baskervville/scss/mixins.scss
+++ b/fonts/google/baskervville/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/battambang/scss/mixins.scss
+++ b/fonts/google/battambang/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/baumans/scss/mixins.scss
+++ b/fonts/google/baumans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bayon/scss/mixins.scss
+++ b/fonts/google/bayon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/be-vietnam-pro/scss/mixins.scss
+++ b/fonts/google/be-vietnam-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/beau-rivage/scss/mixins.scss
+++ b/fonts/google/beau-rivage/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bebas-neue/scss/mixins.scss
+++ b/fonts/google/bebas-neue/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/beiruti/scss/mixins.scss
+++ b/fonts/google/beiruti/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/belanosima/scss/mixins.scss
+++ b/fonts/google/belanosima/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/belgrano/scss/mixins.scss
+++ b/fonts/google/belgrano/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bellefair/scss/mixins.scss
+++ b/fonts/google/bellefair/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/belleza/scss/mixins.scss
+++ b/fonts/google/belleza/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bellota-text/scss/mixins.scss
+++ b/fonts/google/bellota-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bellota/scss/mixins.scss
+++ b/fonts/google/bellota/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/benchnine/scss/mixins.scss
+++ b/fonts/google/benchnine/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/benne/scss/mixins.scss
+++ b/fonts/google/benne/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bentham/scss/mixins.scss
+++ b/fonts/google/bentham/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/berkshire-swash/scss/mixins.scss
+++ b/fonts/google/berkshire-swash/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/besley/scss/mixins.scss
+++ b/fonts/google/besley/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/beth-ellen/scss/mixins.scss
+++ b/fonts/google/beth-ellen/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bevan/scss/mixins.scss
+++ b/fonts/google/bevan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bhutuka-expanded-one/scss/mixins.scss
+++ b/fonts/google/bhutuka-expanded-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/big-shoulders-display/scss/mixins.scss
+++ b/fonts/google/big-shoulders-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/big-shoulders-inline-display/scss/mixins.scss
+++ b/fonts/google/big-shoulders-inline-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/big-shoulders-inline-text/scss/mixins.scss
+++ b/fonts/google/big-shoulders-inline-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/big-shoulders-stencil-display/scss/mixins.scss
+++ b/fonts/google/big-shoulders-stencil-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/big-shoulders-stencil-text/scss/mixins.scss
+++ b/fonts/google/big-shoulders-stencil-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/big-shoulders-text/scss/mixins.scss
+++ b/fonts/google/big-shoulders-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bigelow-rules/scss/mixins.scss
+++ b/fonts/google/bigelow-rules/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bigshot-one/scss/mixins.scss
+++ b/fonts/google/bigshot-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bilbo-swash-caps/scss/mixins.scss
+++ b/fonts/google/bilbo-swash-caps/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bilbo/scss/mixins.scss
+++ b/fonts/google/bilbo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/biorhyme-expanded/scss/mixins.scss
+++ b/fonts/google/biorhyme-expanded/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/biorhyme/scss/mixins.scss
+++ b/fonts/google/biorhyme/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/birthstone-bounce/scss/mixins.scss
+++ b/fonts/google/birthstone-bounce/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/birthstone/scss/mixins.scss
+++ b/fonts/google/birthstone/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/biryani/scss/mixins.scss
+++ b/fonts/google/biryani/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bitter/scss/mixins.scss
+++ b/fonts/google/bitter/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/biz-udgothic/scss/mixins.scss
+++ b/fonts/google/biz-udgothic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/biz-udmincho/scss/mixins.scss
+++ b/fonts/google/biz-udmincho/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/biz-udpgothic/scss/mixins.scss
+++ b/fonts/google/biz-udpgothic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/biz-udpmincho/scss/mixins.scss
+++ b/fonts/google/biz-udpmincho/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/black-and-white-picture/scss/mixins.scss
+++ b/fonts/google/black-and-white-picture/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/black-han-sans/scss/mixins.scss
+++ b/fonts/google/black-han-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/black-ops-one/scss/mixins.scss
+++ b/fonts/google/black-ops-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/blaka-hollow/scss/mixins.scss
+++ b/fonts/google/blaka-hollow/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/blaka-ink/scss/mixins.scss
+++ b/fonts/google/blaka-ink/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/blaka/scss/mixins.scss
+++ b/fonts/google/blaka/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/blinker/scss/mixins.scss
+++ b/fonts/google/blinker/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bodoni-moda-sc/scss/mixins.scss
+++ b/fonts/google/bodoni-moda-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bodoni-moda/scss/mixins.scss
+++ b/fonts/google/bodoni-moda/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bokor/scss/mixins.scss
+++ b/fonts/google/bokor/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bona-nova-sc/scss/mixins.scss
+++ b/fonts/google/bona-nova-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bona-nova/scss/mixins.scss
+++ b/fonts/google/bona-nova/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bonbon/scss/mixins.scss
+++ b/fonts/google/bonbon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bonheur-royale/scss/mixins.scss
+++ b/fonts/google/bonheur-royale/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/boogaloo/scss/mixins.scss
+++ b/fonts/google/boogaloo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/borel/scss/mixins.scss
+++ b/fonts/google/borel/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bowlby-one-sc/scss/mixins.scss
+++ b/fonts/google/bowlby-one-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bowlby-one/scss/mixins.scss
+++ b/fonts/google/bowlby-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/braah-one/scss/mixins.scss
+++ b/fonts/google/braah-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/brawler/scss/mixins.scss
+++ b/fonts/google/brawler/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bree-serif/scss/mixins.scss
+++ b/fonts/google/bree-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bricolage-grotesque/scss/mixins.scss
+++ b/fonts/google/bricolage-grotesque/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/briem-hand/scss/mixins.scss
+++ b/fonts/google/briem-hand/scss/mixins.scss
@@ -95,7 +95,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bruno-ace-sc/scss/mixins.scss
+++ b/fonts/google/bruno-ace-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bruno-ace/scss/mixins.scss
+++ b/fonts/google/bruno-ace/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/brygada-1918/scss/mixins.scss
+++ b/fonts/google/brygada-1918/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bubblegum-sans/scss/mixins.scss
+++ b/fonts/google/bubblegum-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bubbler-one/scss/mixins.scss
+++ b/fonts/google/bubbler-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/buda/scss/mixins.scss
+++ b/fonts/google/buda/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/buenard/scss/mixins.scss
+++ b/fonts/google/buenard/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bungee-hairline/scss/mixins.scss
+++ b/fonts/google/bungee-hairline/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bungee-inline/scss/mixins.scss
+++ b/fonts/google/bungee-inline/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bungee-outline/scss/mixins.scss
+++ b/fonts/google/bungee-outline/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bungee-shade/scss/mixins.scss
+++ b/fonts/google/bungee-shade/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bungee-spice/scss/mixins.scss
+++ b/fonts/google/bungee-spice/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bungee-tint/scss/mixins.scss
+++ b/fonts/google/bungee-tint/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/bungee/scss/mixins.scss
+++ b/fonts/google/bungee/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/butcherman/scss/mixins.scss
+++ b/fonts/google/butcherman/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/butterfly-kids/scss/mixins.scss
+++ b/fonts/google/butterfly-kids/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cabin-condensed/scss/mixins.scss
+++ b/fonts/google/cabin-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cabin-sketch/scss/mixins.scss
+++ b/fonts/google/cabin-sketch/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cabin/scss/mixins.scss
+++ b/fonts/google/cabin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cactus-classical-serif/scss/mixins.scss
+++ b/fonts/google/cactus-classical-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/caesar-dressing/scss/mixins.scss
+++ b/fonts/google/caesar-dressing/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cagliostro/scss/mixins.scss
+++ b/fonts/google/cagliostro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cairo-play/scss/mixins.scss
+++ b/fonts/google/cairo-play/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cairo/scss/mixins.scss
+++ b/fonts/google/cairo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/caladea/scss/mixins.scss
+++ b/fonts/google/caladea/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/calistoga/scss/mixins.scss
+++ b/fonts/google/calistoga/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/calligraffitti/scss/mixins.scss
+++ b/fonts/google/calligraffitti/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cambay/scss/mixins.scss
+++ b/fonts/google/cambay/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cambo/scss/mixins.scss
+++ b/fonts/google/cambo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/candal/scss/mixins.scss
+++ b/fonts/google/candal/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cantarell/scss/mixins.scss
+++ b/fonts/google/cantarell/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cantata-one/scss/mixins.scss
+++ b/fonts/google/cantata-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cantora-one/scss/mixins.scss
+++ b/fonts/google/cantora-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/caprasimo/scss/mixins.scss
+++ b/fonts/google/caprasimo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/capriola/scss/mixins.scss
+++ b/fonts/google/capriola/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/caramel/scss/mixins.scss
+++ b/fonts/google/caramel/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/carattere/scss/mixins.scss
+++ b/fonts/google/carattere/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cardo/scss/mixins.scss
+++ b/fonts/google/cardo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/carlito/scss/mixins.scss
+++ b/fonts/google/carlito/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/carme/scss/mixins.scss
+++ b/fonts/google/carme/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/carrois-gothic-sc/scss/mixins.scss
+++ b/fonts/google/carrois-gothic-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/carrois-gothic/scss/mixins.scss
+++ b/fonts/google/carrois-gothic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/carter-one/scss/mixins.scss
+++ b/fonts/google/carter-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/castoro-titling/scss/mixins.scss
+++ b/fonts/google/castoro-titling/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/castoro/scss/mixins.scss
+++ b/fonts/google/castoro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/catamaran/scss/mixins.scss
+++ b/fonts/google/catamaran/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/caudex/scss/mixins.scss
+++ b/fonts/google/caudex/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/caveat-brush/scss/mixins.scss
+++ b/fonts/google/caveat-brush/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/caveat/scss/mixins.scss
+++ b/fonts/google/caveat/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cedarville-cursive/scss/mixins.scss
+++ b/fonts/google/cedarville-cursive/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ceviche-one/scss/mixins.scss
+++ b/fonts/google/ceviche-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chakra-petch/scss/mixins.scss
+++ b/fonts/google/chakra-petch/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/changa-one/scss/mixins.scss
+++ b/fonts/google/changa-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/changa/scss/mixins.scss
+++ b/fonts/google/changa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chango/scss/mixins.scss
+++ b/fonts/google/chango/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/charis-sil/scss/mixins.scss
+++ b/fonts/google/charis-sil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/charm/scss/mixins.scss
+++ b/fonts/google/charm/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/charmonman/scss/mixins.scss
+++ b/fonts/google/charmonman/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chathura/scss/mixins.scss
+++ b/fonts/google/chathura/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chau-philomene-one/scss/mixins.scss
+++ b/fonts/google/chau-philomene-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chela-one/scss/mixins.scss
+++ b/fonts/google/chela-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chelsea-market/scss/mixins.scss
+++ b/fonts/google/chelsea-market/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chenla/scss/mixins.scss
+++ b/fonts/google/chenla/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cherish/scss/mixins.scss
+++ b/fonts/google/cherish/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cherry-bomb-one/scss/mixins.scss
+++ b/fonts/google/cherry-bomb-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cherry-cream-soda/scss/mixins.scss
+++ b/fonts/google/cherry-cream-soda/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cherry-swash/scss/mixins.scss
+++ b/fonts/google/cherry-swash/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chewy/scss/mixins.scss
+++ b/fonts/google/chewy/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chicle/scss/mixins.scss
+++ b/fonts/google/chicle/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chilanka/scss/mixins.scss
+++ b/fonts/google/chilanka/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chivo-mono/scss/mixins.scss
+++ b/fonts/google/chivo-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chivo/scss/mixins.scss
+++ b/fonts/google/chivo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chocolate-classical-sans/scss/mixins.scss
+++ b/fonts/google/chocolate-classical-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chokokutai/scss/mixins.scss
+++ b/fonts/google/chokokutai/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/chonburi/scss/mixins.scss
+++ b/fonts/google/chonburi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cinzel-decorative/scss/mixins.scss
+++ b/fonts/google/cinzel-decorative/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cinzel/scss/mixins.scss
+++ b/fonts/google/cinzel/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/clicker-script/scss/mixins.scss
+++ b/fonts/google/clicker-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/climate-crisis/scss/mixins.scss
+++ b/fonts/google/climate-crisis/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/coda-caption/scss/mixins.scss
+++ b/fonts/google/coda-caption/scss/mixins.scss
@@ -87,7 +87,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/coda/scss/mixins.scss
+++ b/fonts/google/coda/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/codystar/scss/mixins.scss
+++ b/fonts/google/codystar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/coiny/scss/mixins.scss
+++ b/fonts/google/coiny/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/combo/scss/mixins.scss
+++ b/fonts/google/combo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/comfortaa/scss/mixins.scss
+++ b/fonts/google/comfortaa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/comforter-brush/scss/mixins.scss
+++ b/fonts/google/comforter-brush/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/comforter/scss/mixins.scss
+++ b/fonts/google/comforter/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/comic-neue/scss/mixins.scss
+++ b/fonts/google/comic-neue/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/coming-soon/scss/mixins.scss
+++ b/fonts/google/coming-soon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/comme/scss/mixins.scss
+++ b/fonts/google/comme/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/commissioner/scss/mixins.scss
+++ b/fonts/google/commissioner/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/concert-one/scss/mixins.scss
+++ b/fonts/google/concert-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/condiment/scss/mixins.scss
+++ b/fonts/google/condiment/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/content/scss/mixins.scss
+++ b/fonts/google/content/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/contrail-one/scss/mixins.scss
+++ b/fonts/google/contrail-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/convergence/scss/mixins.scss
+++ b/fonts/google/convergence/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cookie/scss/mixins.scss
+++ b/fonts/google/cookie/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/copse/scss/mixins.scss
+++ b/fonts/google/copse/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/corben/scss/mixins.scss
+++ b/fonts/google/corben/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/corinthia/scss/mixins.scss
+++ b/fonts/google/corinthia/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cormorant-garamond/scss/mixins.scss
+++ b/fonts/google/cormorant-garamond/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cormorant-infant/scss/mixins.scss
+++ b/fonts/google/cormorant-infant/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cormorant-sc/scss/mixins.scss
+++ b/fonts/google/cormorant-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cormorant-unicase/scss/mixins.scss
+++ b/fonts/google/cormorant-unicase/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cormorant-upright/scss/mixins.scss
+++ b/fonts/google/cormorant-upright/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cormorant/scss/mixins.scss
+++ b/fonts/google/cormorant/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/courgette/scss/mixins.scss
+++ b/fonts/google/courgette/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/courier-prime/scss/mixins.scss
+++ b/fonts/google/courier-prime/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cousine/scss/mixins.scss
+++ b/fonts/google/cousine/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/coustard/scss/mixins.scss
+++ b/fonts/google/coustard/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/covered-by-your-grace/scss/mixins.scss
+++ b/fonts/google/covered-by-your-grace/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/crafty-girls/scss/mixins.scss
+++ b/fonts/google/crafty-girls/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/creepster/scss/mixins.scss
+++ b/fonts/google/creepster/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/crete-round/scss/mixins.scss
+++ b/fonts/google/crete-round/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/crimson-pro/scss/mixins.scss
+++ b/fonts/google/crimson-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/crimson-text/scss/mixins.scss
+++ b/fonts/google/crimson-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/croissant-one/scss/mixins.scss
+++ b/fonts/google/croissant-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/crushed/scss/mixins.scss
+++ b/fonts/google/crushed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cuprum/scss/mixins.scss
+++ b/fonts/google/cuprum/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cute-font/scss/mixins.scss
+++ b/fonts/google/cute-font/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cutive-mono/scss/mixins.scss
+++ b/fonts/google/cutive-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/cutive/scss/mixins.scss
+++ b/fonts/google/cutive/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dai-banna-sil/scss/mixins.scss
+++ b/fonts/google/dai-banna-sil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/damion/scss/mixins.scss
+++ b/fonts/google/damion/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dancing-script/scss/mixins.scss
+++ b/fonts/google/dancing-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/danfo/scss/mixins.scss
+++ b/fonts/google/danfo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dangrek/scss/mixins.scss
+++ b/fonts/google/dangrek/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/darker-grotesque/scss/mixins.scss
+++ b/fonts/google/darker-grotesque/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/darumadrop-one/scss/mixins.scss
+++ b/fonts/google/darumadrop-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/david-libre/scss/mixins.scss
+++ b/fonts/google/david-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dawning-of-a-new-day/scss/mixins.scss
+++ b/fonts/google/dawning-of-a-new-day/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/days-one/scss/mixins.scss
+++ b/fonts/google/days-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dekko/scss/mixins.scss
+++ b/fonts/google/dekko/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dela-gothic-one/scss/mixins.scss
+++ b/fonts/google/dela-gothic-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/delicious-handrawn/scss/mixins.scss
+++ b/fonts/google/delicious-handrawn/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/delius-swash-caps/scss/mixins.scss
+++ b/fonts/google/delius-swash-caps/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/delius-unicase/scss/mixins.scss
+++ b/fonts/google/delius-unicase/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/delius/scss/mixins.scss
+++ b/fonts/google/delius/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/della-respira/scss/mixins.scss
+++ b/fonts/google/della-respira/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/denk-one/scss/mixins.scss
+++ b/fonts/google/denk-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/devonshire/scss/mixins.scss
+++ b/fonts/google/devonshire/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dhurjati/scss/mixins.scss
+++ b/fonts/google/dhurjati/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/didact-gothic/scss/mixins.scss
+++ b/fonts/google/didact-gothic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/diphylleia/scss/mixins.scss
+++ b/fonts/google/diphylleia/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/diplomata-sc/scss/mixins.scss
+++ b/fonts/google/diplomata-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/diplomata/scss/mixins.scss
+++ b/fonts/google/diplomata/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dm-mono/scss/mixins.scss
+++ b/fonts/google/dm-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dm-sans/scss/mixins.scss
+++ b/fonts/google/dm-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dm-serif-display/scss/mixins.scss
+++ b/fonts/google/dm-serif-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dm-serif-text/scss/mixins.scss
+++ b/fonts/google/dm-serif-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/do-hyeon/scss/mixins.scss
+++ b/fonts/google/do-hyeon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dokdo/scss/mixins.scss
+++ b/fonts/google/dokdo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/domine/scss/mixins.scss
+++ b/fonts/google/domine/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/donegal-one/scss/mixins.scss
+++ b/fonts/google/donegal-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dongle/scss/mixins.scss
+++ b/fonts/google/dongle/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/doppio-one/scss/mixins.scss
+++ b/fonts/google/doppio-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dorsa/scss/mixins.scss
+++ b/fonts/google/dorsa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dosis/scss/mixins.scss
+++ b/fonts/google/dosis/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dotgothic16/scss/mixins.scss
+++ b/fonts/google/dotgothic16/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/doto/scss/mixins.scss
+++ b/fonts/google/doto/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dr-sugiyama/scss/mixins.scss
+++ b/fonts/google/dr-sugiyama/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/duru-sans/scss/mixins.scss
+++ b/fonts/google/duru-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dynalight/scss/mixins.scss
+++ b/fonts/google/dynalight/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/dynapuff/scss/mixins.scss
+++ b/fonts/google/dynapuff/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/eagle-lake/scss/mixins.scss
+++ b/fonts/google/eagle-lake/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/east-sea-dokdo/scss/mixins.scss
+++ b/fonts/google/east-sea-dokdo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/eater/scss/mixins.scss
+++ b/fonts/google/eater/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/eb-garamond/scss/mixins.scss
+++ b/fonts/google/eb-garamond/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/economica/scss/mixins.scss
+++ b/fonts/google/economica/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/eczar/scss/mixins.scss
+++ b/fonts/google/eczar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/edu-au-vic-wa-nt-arrows/scss/mixins.scss
+++ b/fonts/google/edu-au-vic-wa-nt-arrows/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/edu-au-vic-wa-nt-dots/scss/mixins.scss
+++ b/fonts/google/edu-au-vic-wa-nt-dots/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/edu-au-vic-wa-nt-guides/scss/mixins.scss
+++ b/fonts/google/edu-au-vic-wa-nt-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/edu-au-vic-wa-nt-hand/scss/mixins.scss
+++ b/fonts/google/edu-au-vic-wa-nt-hand/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/edu-au-vic-wa-nt-pre/scss/mixins.scss
+++ b/fonts/google/edu-au-vic-wa-nt-pre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/edu-nsw-act-foundation/scss/mixins.scss
+++ b/fonts/google/edu-nsw-act-foundation/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/edu-qld-beginner/scss/mixins.scss
+++ b/fonts/google/edu-qld-beginner/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/edu-sa-beginner/scss/mixins.scss
+++ b/fonts/google/edu-sa-beginner/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/edu-tas-beginner/scss/mixins.scss
+++ b/fonts/google/edu-tas-beginner/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/edu-vic-wa-nt-beginner/scss/mixins.scss
+++ b/fonts/google/edu-vic-wa-nt-beginner/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/el-messiri/scss/mixins.scss
+++ b/fonts/google/el-messiri/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/electrolize/scss/mixins.scss
+++ b/fonts/google/electrolize/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/elsie-swash-caps/scss/mixins.scss
+++ b/fonts/google/elsie-swash-caps/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/elsie/scss/mixins.scss
+++ b/fonts/google/elsie/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/emblema-one/scss/mixins.scss
+++ b/fonts/google/emblema-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/emilys-candy/scss/mixins.scss
+++ b/fonts/google/emilys-candy/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/encode-sans-condensed/scss/mixins.scss
+++ b/fonts/google/encode-sans-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/encode-sans-expanded/scss/mixins.scss
+++ b/fonts/google/encode-sans-expanded/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/encode-sans-sc/scss/mixins.scss
+++ b/fonts/google/encode-sans-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/encode-sans-semi-condensed/scss/mixins.scss
+++ b/fonts/google/encode-sans-semi-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/encode-sans-semi-expanded/scss/mixins.scss
+++ b/fonts/google/encode-sans-semi-expanded/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/encode-sans/scss/mixins.scss
+++ b/fonts/google/encode-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/engagement/scss/mixins.scss
+++ b/fonts/google/engagement/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/englebert/scss/mixins.scss
+++ b/fonts/google/englebert/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/enriqueta/scss/mixins.scss
+++ b/fonts/google/enriqueta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ephesis/scss/mixins.scss
+++ b/fonts/google/ephesis/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/epilogue/scss/mixins.scss
+++ b/fonts/google/epilogue/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/erica-one/scss/mixins.scss
+++ b/fonts/google/erica-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/esteban/scss/mixins.scss
+++ b/fonts/google/esteban/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/estonia/scss/mixins.scss
+++ b/fonts/google/estonia/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/euphoria-script/scss/mixins.scss
+++ b/fonts/google/euphoria-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ewert/scss/mixins.scss
+++ b/fonts/google/ewert/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/exo-2/scss/mixins.scss
+++ b/fonts/google/exo-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/exo/scss/mixins.scss
+++ b/fonts/google/exo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/expletus-sans/scss/mixins.scss
+++ b/fonts/google/expletus-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/explora/scss/mixins.scss
+++ b/fonts/google/explora/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/faculty-glyphic/scss/mixins.scss
+++ b/fonts/google/faculty-glyphic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fahkwang/scss/mixins.scss
+++ b/fonts/google/fahkwang/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/familjen-grotesk/scss/mixins.scss
+++ b/fonts/google/familjen-grotesk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fanwood-text/scss/mixins.scss
+++ b/fonts/google/fanwood-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/farro/scss/mixins.scss
+++ b/fonts/google/farro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/farsan/scss/mixins.scss
+++ b/fonts/google/farsan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fascinate-inline/scss/mixins.scss
+++ b/fonts/google/fascinate-inline/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fascinate/scss/mixins.scss
+++ b/fonts/google/fascinate/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/faster-one/scss/mixins.scss
+++ b/fonts/google/faster-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fasthand/scss/mixins.scss
+++ b/fonts/google/fasthand/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fauna-one/scss/mixins.scss
+++ b/fonts/google/fauna-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/faustina/scss/mixins.scss
+++ b/fonts/google/faustina/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/federant/scss/mixins.scss
+++ b/fonts/google/federant/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/federo/scss/mixins.scss
+++ b/fonts/google/federo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/felipa/scss/mixins.scss
+++ b/fonts/google/felipa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fenix/scss/mixins.scss
+++ b/fonts/google/fenix/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/festive/scss/mixins.scss
+++ b/fonts/google/festive/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/figtree/scss/mixins.scss
+++ b/fonts/google/figtree/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/finger-paint/scss/mixins.scss
+++ b/fonts/google/finger-paint/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/finlandica/scss/mixins.scss
+++ b/fonts/google/finlandica/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fira-code/scss/mixins.scss
+++ b/fonts/google/fira-code/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fira-mono/scss/mixins.scss
+++ b/fonts/google/fira-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fira-sans-condensed/scss/mixins.scss
+++ b/fonts/google/fira-sans-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fira-sans-extra-condensed/scss/mixins.scss
+++ b/fonts/google/fira-sans-extra-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fira-sans/scss/mixins.scss
+++ b/fonts/google/fira-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fjalla-one/scss/mixins.scss
+++ b/fonts/google/fjalla-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fjord-one/scss/mixins.scss
+++ b/fonts/google/fjord-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/flamenco/scss/mixins.scss
+++ b/fonts/google/flamenco/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/flavors/scss/mixins.scss
+++ b/fonts/google/flavors/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fleur-de-leah/scss/mixins.scss
+++ b/fonts/google/fleur-de-leah/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/flow-block/scss/mixins.scss
+++ b/fonts/google/flow-block/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/flow-circular/scss/mixins.scss
+++ b/fonts/google/flow-circular/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/flow-rounded/scss/mixins.scss
+++ b/fonts/google/flow-rounded/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/foldit/scss/mixins.scss
+++ b/fonts/google/foldit/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fondamento/scss/mixins.scss
+++ b/fonts/google/fondamento/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fontdiner-swanky/scss/mixins.scss
+++ b/fonts/google/fontdiner-swanky/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/forum/scss/mixins.scss
+++ b/fonts/google/forum/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fragment-mono/scss/mixins.scss
+++ b/fonts/google/fragment-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/francois-one/scss/mixins.scss
+++ b/fonts/google/francois-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/frank-ruhl-libre/scss/mixins.scss
+++ b/fonts/google/frank-ruhl-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fraunces/scss/mixins.scss
+++ b/fonts/google/fraunces/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/freckle-face/scss/mixins.scss
+++ b/fonts/google/freckle-face/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fredericka-the-great/scss/mixins.scss
+++ b/fonts/google/fredericka-the-great/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fredoka-one/scss/mixins.scss
+++ b/fonts/google/fredoka-one/scss/mixins.scss
@@ -84,7 +84,7 @@ $axes: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),
@@ -114,18 +114,18 @@ $axes: null !default;
 
                 font-family: string.quote($family),
                 font-style: if(
-                  ($axis == full or $axis == slnt) and map.has-key($metadata, axes, slnt), 
+                  ($axis == full or $axis == slnt) and map.has-key($metadata, axes, slnt),
                   oblique map.get($metadata, axes, slnt, min) + deg map.get($metadata, axes, slnt, max) + deg,
                   $style
                 ),
                 font-display: if($displayVar, var(--fontsource-display, $display), $display),
                 font-weight: if(
-                  ($axis == full or $axis == wght) and map.has-key($metadata, axes, wght), 
+                  ($axis == full or $axis == wght) and map.has-key($metadata, axes, wght),
                   map.get($metadata, axes, wght, min) map.get($metadata, axes, wght, max),
                   $weight
                 ),
                 font-stretch: if(
-                  ($axis == full or $axis == wdth) and map.has-key($metadata, axes, wdth), 
+                  ($axis == full or $axis == wdth) and map.has-key($metadata, axes, wdth),
                   '#{map.get($metadata, axes, wdth, min)}% #{map.get($metadata, axes, wdth, max)}%',
                   null
                 ),

--- a/fonts/google/fredoka/scss/mixins.scss
+++ b/fonts/google/fredoka/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/freehand/scss/mixins.scss
+++ b/fonts/google/freehand/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/freeman/scss/mixins.scss
+++ b/fonts/google/freeman/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fresca/scss/mixins.scss
+++ b/fonts/google/fresca/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/frijole/scss/mixins.scss
+++ b/fonts/google/frijole/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fruktur/scss/mixins.scss
+++ b/fonts/google/fruktur/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fugaz-one/scss/mixins.scss
+++ b/fonts/google/fugaz-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fuggles/scss/mixins.scss
+++ b/fonts/google/fuggles/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/funnel-display/scss/mixins.scss
+++ b/fonts/google/funnel-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/funnel-sans/scss/mixins.scss
+++ b/fonts/google/funnel-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fustat/scss/mixins.scss
+++ b/fonts/google/fustat/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/fuzzy-bubbles/scss/mixins.scss
+++ b/fonts/google/fuzzy-bubbles/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ga-maamli/scss/mixins.scss
+++ b/fonts/google/ga-maamli/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gabarito/scss/mixins.scss
+++ b/fonts/google/gabarito/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gabriela/scss/mixins.scss
+++ b/fonts/google/gabriela/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gaegu/scss/mixins.scss
+++ b/fonts/google/gaegu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gafata/scss/mixins.scss
+++ b/fonts/google/gafata/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gajraj-one/scss/mixins.scss
+++ b/fonts/google/gajraj-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/galada/scss/mixins.scss
+++ b/fonts/google/galada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/galdeano/scss/mixins.scss
+++ b/fonts/google/galdeano/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/galindo/scss/mixins.scss
+++ b/fonts/google/galindo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gamja-flower/scss/mixins.scss
+++ b/fonts/google/gamja-flower/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gantari/scss/mixins.scss
+++ b/fonts/google/gantari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gasoek-one/scss/mixins.scss
+++ b/fonts/google/gasoek-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gayathri/scss/mixins.scss
+++ b/fonts/google/gayathri/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/geist-mono/scss/mixins.scss
+++ b/fonts/google/geist-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/geist/scss/mixins.scss
+++ b/fonts/google/geist/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gelasio/scss/mixins.scss
+++ b/fonts/google/gelasio/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gemunu-libre/scss/mixins.scss
+++ b/fonts/google/gemunu-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/genos/scss/mixins.scss
+++ b/fonts/google/genos/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gentium-book-basic/scss/mixins.scss
+++ b/fonts/google/gentium-book-basic/scss/mixins.scss
@@ -84,7 +84,7 @@ $axes: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),
@@ -114,18 +114,18 @@ $axes: null !default;
 
                 font-family: string.quote($family),
                 font-style: if(
-                  ($axis == full or $axis == slnt) and map.has-key($metadata, axes, slnt), 
+                  ($axis == full or $axis == slnt) and map.has-key($metadata, axes, slnt),
                   oblique map.get($metadata, axes, slnt, min) + deg map.get($metadata, axes, slnt, max) + deg,
                   $style
                 ),
                 font-display: if($displayVar, var(--fontsource-display, $display), $display),
                 font-weight: if(
-                  ($axis == full or $axis == wght) and map.has-key($metadata, axes, wght), 
+                  ($axis == full or $axis == wght) and map.has-key($metadata, axes, wght),
                   map.get($metadata, axes, wght, min) map.get($metadata, axes, wght, max),
                   $weight
                 ),
                 font-stretch: if(
-                  ($axis == full or $axis == wdth) and map.has-key($metadata, axes, wdth), 
+                  ($axis == full or $axis == wdth) and map.has-key($metadata, axes, wdth),
                   '#{map.get($metadata, axes, wdth, min)}% #{map.get($metadata, axes, wdth, max)}%',
                   null
                 ),

--- a/fonts/google/gentium-book-plus/scss/mixins.scss
+++ b/fonts/google/gentium-book-plus/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gentium-plus/scss/mixins.scss
+++ b/fonts/google/gentium-plus/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/geo/scss/mixins.scss
+++ b/fonts/google/geo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/geologica/scss/mixins.scss
+++ b/fonts/google/geologica/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/georama/scss/mixins.scss
+++ b/fonts/google/georama/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/geostar-fill/scss/mixins.scss
+++ b/fonts/google/geostar-fill/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/geostar/scss/mixins.scss
+++ b/fonts/google/geostar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/germania-one/scss/mixins.scss
+++ b/fonts/google/germania-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gfs-didot/scss/mixins.scss
+++ b/fonts/google/gfs-didot/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gfs-neohellenic/scss/mixins.scss
+++ b/fonts/google/gfs-neohellenic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gideon-roman/scss/mixins.scss
+++ b/fonts/google/gideon-roman/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gidugu/scss/mixins.scss
+++ b/fonts/google/gidugu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gilda-display/scss/mixins.scss
+++ b/fonts/google/gilda-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/girassol/scss/mixins.scss
+++ b/fonts/google/girassol/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/give-you-glory/scss/mixins.scss
+++ b/fonts/google/give-you-glory/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/glass-antiqua/scss/mixins.scss
+++ b/fonts/google/glass-antiqua/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/glegoo/scss/mixins.scss
+++ b/fonts/google/glegoo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gloock/scss/mixins.scss
+++ b/fonts/google/gloock/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gloria-hallelujah/scss/mixins.scss
+++ b/fonts/google/gloria-hallelujah/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/glory/scss/mixins.scss
+++ b/fonts/google/glory/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gluten/scss/mixins.scss
+++ b/fonts/google/gluten/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/goblin-one/scss/mixins.scss
+++ b/fonts/google/goblin-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gochi-hand/scss/mixins.scss
+++ b/fonts/google/gochi-hand/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/goldman/scss/mixins.scss
+++ b/fonts/google/goldman/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/golos-text/scss/mixins.scss
+++ b/fonts/google/golos-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gorditas/scss/mixins.scss
+++ b/fonts/google/gorditas/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gothic-a1/scss/mixins.scss
+++ b/fonts/google/gothic-a1/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gotu/scss/mixins.scss
+++ b/fonts/google/gotu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/goudy-bookletter-1911/scss/mixins.scss
+++ b/fonts/google/goudy-bookletter-1911/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gowun-batang/scss/mixins.scss
+++ b/fonts/google/gowun-batang/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gowun-dodum/scss/mixins.scss
+++ b/fonts/google/gowun-dodum/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/graduate/scss/mixins.scss
+++ b/fonts/google/graduate/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/grand-hotel/scss/mixins.scss
+++ b/fonts/google/grand-hotel/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/grandiflora-one/scss/mixins.scss
+++ b/fonts/google/grandiflora-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/grandstander/scss/mixins.scss
+++ b/fonts/google/grandstander/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/grape-nuts/scss/mixins.scss
+++ b/fonts/google/grape-nuts/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gravitas-one/scss/mixins.scss
+++ b/fonts/google/gravitas-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/great-vibes/scss/mixins.scss
+++ b/fonts/google/great-vibes/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/grechen-fuemen/scss/mixins.scss
+++ b/fonts/google/grechen-fuemen/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/grenze-gotisch/scss/mixins.scss
+++ b/fonts/google/grenze-gotisch/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/grenze/scss/mixins.scss
+++ b/fonts/google/grenze/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/grey-qo/scss/mixins.scss
+++ b/fonts/google/grey-qo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/griffy/scss/mixins.scss
+++ b/fonts/google/griffy/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gruppo/scss/mixins.scss
+++ b/fonts/google/gruppo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gudea/scss/mixins.scss
+++ b/fonts/google/gudea/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gugi/scss/mixins.scss
+++ b/fonts/google/gugi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gulzar/scss/mixins.scss
+++ b/fonts/google/gulzar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gupter/scss/mixins.scss
+++ b/fonts/google/gupter/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gurajada/scss/mixins.scss
+++ b/fonts/google/gurajada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/gwendolyn/scss/mixins.scss
+++ b/fonts/google/gwendolyn/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/habibi/scss/mixins.scss
+++ b/fonts/google/habibi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hachi-maru-pop/scss/mixins.scss
+++ b/fonts/google/hachi-maru-pop/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hahmlet/scss/mixins.scss
+++ b/fonts/google/hahmlet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/halant/scss/mixins.scss
+++ b/fonts/google/halant/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hammersmith-one/scss/mixins.scss
+++ b/fonts/google/hammersmith-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hanalei-fill/scss/mixins.scss
+++ b/fonts/google/hanalei-fill/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hanalei/scss/mixins.scss
+++ b/fonts/google/hanalei/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/handjet/scss/mixins.scss
+++ b/fonts/google/handjet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/handlee/scss/mixins.scss
+++ b/fonts/google/handlee/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hanken-grotesk/scss/mixins.scss
+++ b/fonts/google/hanken-grotesk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hanuman/scss/mixins.scss
+++ b/fonts/google/hanuman/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/happy-monkey/scss/mixins.scss
+++ b/fonts/google/happy-monkey/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/harmattan/scss/mixins.scss
+++ b/fonts/google/harmattan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/headland-one/scss/mixins.scss
+++ b/fonts/google/headland-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hedvig-letters-sans/scss/mixins.scss
+++ b/fonts/google/hedvig-letters-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hedvig-letters-serif/scss/mixins.scss
+++ b/fonts/google/hedvig-letters-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/heebo/scss/mixins.scss
+++ b/fonts/google/heebo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/henny-penny/scss/mixins.scss
+++ b/fonts/google/henny-penny/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hepta-slab/scss/mixins.scss
+++ b/fonts/google/hepta-slab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/herr-von-muellerhoff/scss/mixins.scss
+++ b/fonts/google/herr-von-muellerhoff/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hi-melody/scss/mixins.scss
+++ b/fonts/google/hi-melody/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hina-mincho/scss/mixins.scss
+++ b/fonts/google/hina-mincho/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hind-guntur/scss/mixins.scss
+++ b/fonts/google/hind-guntur/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hind-madurai/scss/mixins.scss
+++ b/fonts/google/hind-madurai/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hind-mysuru/scss/mixins.scss
+++ b/fonts/google/hind-mysuru/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hind-siliguri/scss/mixins.scss
+++ b/fonts/google/hind-siliguri/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hind-vadodara/scss/mixins.scss
+++ b/fonts/google/hind-vadodara/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hind/scss/mixins.scss
+++ b/fonts/google/hind/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/holtwood-one-sc/scss/mixins.scss
+++ b/fonts/google/holtwood-one-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/homemade-apple/scss/mixins.scss
+++ b/fonts/google/homemade-apple/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/homenaje/scss/mixins.scss
+++ b/fonts/google/homenaje/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/honk/scss/mixins.scss
+++ b/fonts/google/honk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/host-grotesk/scss/mixins.scss
+++ b/fonts/google/host-grotesk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hubballi/scss/mixins.scss
+++ b/fonts/google/hubballi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hubot-sans/scss/mixins.scss
+++ b/fonts/google/hubot-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/hurricane/scss/mixins.scss
+++ b/fonts/google/hurricane/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ibarra-real-nova/scss/mixins.scss
+++ b/fonts/google/ibarra-real-nova/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ibm-plex-mono/scss/mixins.scss
+++ b/fonts/google/ibm-plex-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ibm-plex-sans-arabic/scss/mixins.scss
+++ b/fonts/google/ibm-plex-sans-arabic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ibm-plex-sans-condensed/scss/mixins.scss
+++ b/fonts/google/ibm-plex-sans-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ibm-plex-sans-devanagari/scss/mixins.scss
+++ b/fonts/google/ibm-plex-sans-devanagari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ibm-plex-sans-hebrew/scss/mixins.scss
+++ b/fonts/google/ibm-plex-sans-hebrew/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ibm-plex-sans-jp/scss/mixins.scss
+++ b/fonts/google/ibm-plex-sans-jp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ibm-plex-sans-kr/scss/mixins.scss
+++ b/fonts/google/ibm-plex-sans-kr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ibm-plex-sans-thai-looped/scss/mixins.scss
+++ b/fonts/google/ibm-plex-sans-thai-looped/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ibm-plex-sans-thai/scss/mixins.scss
+++ b/fonts/google/ibm-plex-sans-thai/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ibm-plex-sans/scss/mixins.scss
+++ b/fonts/google/ibm-plex-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ibm-plex-serif/scss/mixins.scss
+++ b/fonts/google/ibm-plex-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/iceberg/scss/mixins.scss
+++ b/fonts/google/iceberg/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/iceland/scss/mixins.scss
+++ b/fonts/google/iceland/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/im-fell-double-pica-sc/scss/mixins.scss
+++ b/fonts/google/im-fell-double-pica-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/im-fell-double-pica/scss/mixins.scss
+++ b/fonts/google/im-fell-double-pica/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/im-fell-dw-pica-sc/scss/mixins.scss
+++ b/fonts/google/im-fell-dw-pica-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/im-fell-dw-pica/scss/mixins.scss
+++ b/fonts/google/im-fell-dw-pica/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/im-fell-english-sc/scss/mixins.scss
+++ b/fonts/google/im-fell-english-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/im-fell-english/scss/mixins.scss
+++ b/fonts/google/im-fell-english/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/im-fell-french-canon-sc/scss/mixins.scss
+++ b/fonts/google/im-fell-french-canon-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/im-fell-french-canon/scss/mixins.scss
+++ b/fonts/google/im-fell-french-canon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/im-fell-great-primer-sc/scss/mixins.scss
+++ b/fonts/google/im-fell-great-primer-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/im-fell-great-primer/scss/mixins.scss
+++ b/fonts/google/im-fell-great-primer/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/imbue/scss/mixins.scss
+++ b/fonts/google/imbue/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/imperial-script/scss/mixins.scss
+++ b/fonts/google/imperial-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/imprima/scss/mixins.scss
+++ b/fonts/google/imprima/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/inclusive-sans/scss/mixins.scss
+++ b/fonts/google/inclusive-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/inconsolata/scss/mixins.scss
+++ b/fonts/google/inconsolata/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/inder/scss/mixins.scss
+++ b/fonts/google/inder/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/indie-flower/scss/mixins.scss
+++ b/fonts/google/indie-flower/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ingrid-darling/scss/mixins.scss
+++ b/fonts/google/ingrid-darling/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/inika/scss/mixins.scss
+++ b/fonts/google/inika/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/inknut-antiqua/scss/mixins.scss
+++ b/fonts/google/inknut-antiqua/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/inria-sans/scss/mixins.scss
+++ b/fonts/google/inria-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/inria-serif/scss/mixins.scss
+++ b/fonts/google/inria-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/inspiration/scss/mixins.scss
+++ b/fonts/google/inspiration/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/instrument-sans/scss/mixins.scss
+++ b/fonts/google/instrument-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/instrument-serif/scss/mixins.scss
+++ b/fonts/google/instrument-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/inter-tight/scss/mixins.scss
+++ b/fonts/google/inter-tight/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/inter/scss/mixins.scss
+++ b/fonts/google/inter/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/irish-grover/scss/mixins.scss
+++ b/fonts/google/irish-grover/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/island-moments/scss/mixins.scss
+++ b/fonts/google/island-moments/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/istok-web/scss/mixins.scss
+++ b/fonts/google/istok-web/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/italiana/scss/mixins.scss
+++ b/fonts/google/italiana/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/italianno/scss/mixins.scss
+++ b/fonts/google/italianno/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/itim/scss/mixins.scss
+++ b/fonts/google/itim/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jacquard-12-charted/scss/mixins.scss
+++ b/fonts/google/jacquard-12-charted/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jacquard-12/scss/mixins.scss
+++ b/fonts/google/jacquard-12/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jacquard-24-charted/scss/mixins.scss
+++ b/fonts/google/jacquard-24-charted/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jacquard-24/scss/mixins.scss
+++ b/fonts/google/jacquard-24/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jacquarda-bastarda-9-charted/scss/mixins.scss
+++ b/fonts/google/jacquarda-bastarda-9-charted/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jacquarda-bastarda-9/scss/mixins.scss
+++ b/fonts/google/jacquarda-bastarda-9/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jacques-francois-shadow/scss/mixins.scss
+++ b/fonts/google/jacques-francois-shadow/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jacques-francois/scss/mixins.scss
+++ b/fonts/google/jacques-francois/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jaini-purva/scss/mixins.scss
+++ b/fonts/google/jaini-purva/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jaini/scss/mixins.scss
+++ b/fonts/google/jaini/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jaldi/scss/mixins.scss
+++ b/fonts/google/jaldi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jaro/scss/mixins.scss
+++ b/fonts/google/jaro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jersey-10-charted/scss/mixins.scss
+++ b/fonts/google/jersey-10-charted/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jersey-10/scss/mixins.scss
+++ b/fonts/google/jersey-10/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jersey-15-charted/scss/mixins.scss
+++ b/fonts/google/jersey-15-charted/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jersey-15/scss/mixins.scss
+++ b/fonts/google/jersey-15/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jersey-20-charted/scss/mixins.scss
+++ b/fonts/google/jersey-20-charted/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jersey-20/scss/mixins.scss
+++ b/fonts/google/jersey-20/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jersey-25-charted/scss/mixins.scss
+++ b/fonts/google/jersey-25-charted/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jersey-25/scss/mixins.scss
+++ b/fonts/google/jersey-25/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jetbrains-mono/scss/mixins.scss
+++ b/fonts/google/jetbrains-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jim-nightshade/scss/mixins.scss
+++ b/fonts/google/jim-nightshade/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/joan/scss/mixins.scss
+++ b/fonts/google/joan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jockey-one/scss/mixins.scss
+++ b/fonts/google/jockey-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jolly-lodger/scss/mixins.scss
+++ b/fonts/google/jolly-lodger/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jomhuria/scss/mixins.scss
+++ b/fonts/google/jomhuria/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jomolhari/scss/mixins.scss
+++ b/fonts/google/jomolhari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/josefin-sans/scss/mixins.scss
+++ b/fonts/google/josefin-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/josefin-slab/scss/mixins.scss
+++ b/fonts/google/josefin-slab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jost/scss/mixins.scss
+++ b/fonts/google/jost/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/joti-one/scss/mixins.scss
+++ b/fonts/google/joti-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jua/scss/mixins.scss
+++ b/fonts/google/jua/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/judson/scss/mixins.scss
+++ b/fonts/google/judson/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/julee/scss/mixins.scss
+++ b/fonts/google/julee/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/julius-sans-one/scss/mixins.scss
+++ b/fonts/google/julius-sans-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/junge/scss/mixins.scss
+++ b/fonts/google/junge/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/jura/scss/mixins.scss
+++ b/fonts/google/jura/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/just-another-hand/scss/mixins.scss
+++ b/fonts/google/just-another-hand/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/just-me-again-down-here/scss/mixins.scss
+++ b/fonts/google/just-me-again-down-here/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/k2d/scss/mixins.scss
+++ b/fonts/google/k2d/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kablammo/scss/mixins.scss
+++ b/fonts/google/kablammo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kadwa/scss/mixins.scss
+++ b/fonts/google/kadwa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kaisei-decol/scss/mixins.scss
+++ b/fonts/google/kaisei-decol/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kaisei-harunoumi/scss/mixins.scss
+++ b/fonts/google/kaisei-harunoumi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kaisei-opti/scss/mixins.scss
+++ b/fonts/google/kaisei-opti/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kaisei-tokumin/scss/mixins.scss
+++ b/fonts/google/kaisei-tokumin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kalam/scss/mixins.scss
+++ b/fonts/google/kalam/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kalnia-glaze/scss/mixins.scss
+++ b/fonts/google/kalnia-glaze/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kalnia/scss/mixins.scss
+++ b/fonts/google/kalnia/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kameron/scss/mixins.scss
+++ b/fonts/google/kameron/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kanit/scss/mixins.scss
+++ b/fonts/google/kanit/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kantumruy-pro/scss/mixins.scss
+++ b/fonts/google/kantumruy-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kantumruy/scss/mixins.scss
+++ b/fonts/google/kantumruy/scss/mixins.scss
@@ -84,7 +84,7 @@ $axes: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),
@@ -114,18 +114,18 @@ $axes: null !default;
 
                 font-family: string.quote($family),
                 font-style: if(
-                  ($axis == full or $axis == slnt) and map.has-key($metadata, axes, slnt), 
+                  ($axis == full or $axis == slnt) and map.has-key($metadata, axes, slnt),
                   oblique map.get($metadata, axes, slnt, min) + deg map.get($metadata, axes, slnt, max) + deg,
                   $style
                 ),
                 font-display: if($displayVar, var(--fontsource-display, $display), $display),
                 font-weight: if(
-                  ($axis == full or $axis == wght) and map.has-key($metadata, axes, wght), 
+                  ($axis == full or $axis == wght) and map.has-key($metadata, axes, wght),
                   map.get($metadata, axes, wght, min) map.get($metadata, axes, wght, max),
                   $weight
                 ),
                 font-stretch: if(
-                  ($axis == full or $axis == wdth) and map.has-key($metadata, axes, wdth), 
+                  ($axis == full or $axis == wdth) and map.has-key($metadata, axes, wdth),
                   '#{map.get($metadata, axes, wdth, min)}% #{map.get($metadata, axes, wdth, max)}%',
                   null
                 ),

--- a/fonts/google/karantina/scss/mixins.scss
+++ b/fonts/google/karantina/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/karla-tamil-inclined/scss/mixins.scss
+++ b/fonts/google/karla-tamil-inclined/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/karla-tamil-upright/scss/mixins.scss
+++ b/fonts/google/karla-tamil-upright/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/karla/scss/mixins.scss
+++ b/fonts/google/karla/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/karma/scss/mixins.scss
+++ b/fonts/google/karma/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/katibeh/scss/mixins.scss
+++ b/fonts/google/katibeh/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kaushan-script/scss/mixins.scss
+++ b/fonts/google/kaushan-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kavivanar/scss/mixins.scss
+++ b/fonts/google/kavivanar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kavoon/scss/mixins.scss
+++ b/fonts/google/kavoon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kay-pho-du/scss/mixins.scss
+++ b/fonts/google/kay-pho-du/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kdam-thmor-pro/scss/mixins.scss
+++ b/fonts/google/kdam-thmor-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/keania-one/scss/mixins.scss
+++ b/fonts/google/keania-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kelly-slab/scss/mixins.scss
+++ b/fonts/google/kelly-slab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kenia/scss/mixins.scss
+++ b/fonts/google/kenia/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/khand/scss/mixins.scss
+++ b/fonts/google/khand/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/khmer/scss/mixins.scss
+++ b/fonts/google/khmer/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/khula/scss/mixins.scss
+++ b/fonts/google/khula/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kings/scss/mixins.scss
+++ b/fonts/google/kings/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kirang-haerang/scss/mixins.scss
+++ b/fonts/google/kirang-haerang/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kite-one/scss/mixins.scss
+++ b/fonts/google/kite-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kiwi-maru/scss/mixins.scss
+++ b/fonts/google/kiwi-maru/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/klee-one/scss/mixins.scss
+++ b/fonts/google/klee-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/knewave/scss/mixins.scss
+++ b/fonts/google/knewave/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kodchasan/scss/mixins.scss
+++ b/fonts/google/kodchasan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kode-mono/scss/mixins.scss
+++ b/fonts/google/kode-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/koh-santepheap/scss/mixins.scss
+++ b/fonts/google/koh-santepheap/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/koho/scss/mixins.scss
+++ b/fonts/google/koho/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kolker-brush/scss/mixins.scss
+++ b/fonts/google/kolker-brush/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/konkhmer-sleokchher/scss/mixins.scss
+++ b/fonts/google/konkhmer-sleokchher/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kosugi-maru/scss/mixins.scss
+++ b/fonts/google/kosugi-maru/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kosugi/scss/mixins.scss
+++ b/fonts/google/kosugi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kotta-one/scss/mixins.scss
+++ b/fonts/google/kotta-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/koulen/scss/mixins.scss
+++ b/fonts/google/koulen/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kranky/scss/mixins.scss
+++ b/fonts/google/kranky/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kreon/scss/mixins.scss
+++ b/fonts/google/kreon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kristi/scss/mixins.scss
+++ b/fonts/google/kristi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/krona-one/scss/mixins.scss
+++ b/fonts/google/krona-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/krub/scss/mixins.scss
+++ b/fonts/google/krub/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kufam/scss/mixins.scss
+++ b/fonts/google/kufam/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kulim-park/scss/mixins.scss
+++ b/fonts/google/kulim-park/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kumar-one-outline/scss/mixins.scss
+++ b/fonts/google/kumar-one-outline/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kumar-one/scss/mixins.scss
+++ b/fonts/google/kumar-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kumbh-sans/scss/mixins.scss
+++ b/fonts/google/kumbh-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/kurale/scss/mixins.scss
+++ b/fonts/google/kurale/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/la-belle-aurore/scss/mixins.scss
+++ b/fonts/google/la-belle-aurore/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/labrada/scss/mixins.scss
+++ b/fonts/google/labrada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lacquer/scss/mixins.scss
+++ b/fonts/google/lacquer/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/laila/scss/mixins.scss
+++ b/fonts/google/laila/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lakki-reddy/scss/mixins.scss
+++ b/fonts/google/lakki-reddy/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lalezar/scss/mixins.scss
+++ b/fonts/google/lalezar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lancelot/scss/mixins.scss
+++ b/fonts/google/lancelot/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/langar/scss/mixins.scss
+++ b/fonts/google/langar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lateef/scss/mixins.scss
+++ b/fonts/google/lateef/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lato/scss/mixins.scss
+++ b/fonts/google/lato/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lavishly-yours/scss/mixins.scss
+++ b/fonts/google/lavishly-yours/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/league-gothic/scss/mixins.scss
+++ b/fonts/google/league-gothic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/league-script/scss/mixins.scss
+++ b/fonts/google/league-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/league-spartan/scss/mixins.scss
+++ b/fonts/google/league-spartan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/leckerli-one/scss/mixins.scss
+++ b/fonts/google/leckerli-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ledger/scss/mixins.scss
+++ b/fonts/google/ledger/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lekton/scss/mixins.scss
+++ b/fonts/google/lekton/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lemon/scss/mixins.scss
+++ b/fonts/google/lemon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lemonada/scss/mixins.scss
+++ b/fonts/google/lemonada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lexend-deca/scss/mixins.scss
+++ b/fonts/google/lexend-deca/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lexend-exa/scss/mixins.scss
+++ b/fonts/google/lexend-exa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lexend-giga/scss/mixins.scss
+++ b/fonts/google/lexend-giga/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lexend-mega/scss/mixins.scss
+++ b/fonts/google/lexend-mega/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lexend-peta/scss/mixins.scss
+++ b/fonts/google/lexend-peta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lexend-tera/scss/mixins.scss
+++ b/fonts/google/lexend-tera/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lexend-zetta/scss/mixins.scss
+++ b/fonts/google/lexend-zetta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lexend/scss/mixins.scss
+++ b/fonts/google/lexend/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/libre-barcode-128-text/scss/mixins.scss
+++ b/fonts/google/libre-barcode-128-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/libre-barcode-128/scss/mixins.scss
+++ b/fonts/google/libre-barcode-128/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/libre-barcode-39-extended-text/scss/mixins.scss
+++ b/fonts/google/libre-barcode-39-extended-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/libre-barcode-39-extended/scss/mixins.scss
+++ b/fonts/google/libre-barcode-39-extended/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/libre-barcode-39-text/scss/mixins.scss
+++ b/fonts/google/libre-barcode-39-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/libre-barcode-39/scss/mixins.scss
+++ b/fonts/google/libre-barcode-39/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/libre-barcode-ean13-text/scss/mixins.scss
+++ b/fonts/google/libre-barcode-ean13-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/libre-baskerville/scss/mixins.scss
+++ b/fonts/google/libre-baskerville/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/libre-bodoni/scss/mixins.scss
+++ b/fonts/google/libre-bodoni/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/libre-caslon-display/scss/mixins.scss
+++ b/fonts/google/libre-caslon-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/libre-caslon-text/scss/mixins.scss
+++ b/fonts/google/libre-caslon-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/libre-franklin/scss/mixins.scss
+++ b/fonts/google/libre-franklin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/licorice/scss/mixins.scss
+++ b/fonts/google/licorice/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/life-savers/scss/mixins.scss
+++ b/fonts/google/life-savers/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lilita-one/scss/mixins.scss
+++ b/fonts/google/lilita-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lily-script-one/scss/mixins.scss
+++ b/fonts/google/lily-script-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/limelight/scss/mixins.scss
+++ b/fonts/google/limelight/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/linden-hill/scss/mixins.scss
+++ b/fonts/google/linden-hill/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/linefont/scss/mixins.scss
+++ b/fonts/google/linefont/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lisu-bosa/scss/mixins.scss
+++ b/fonts/google/lisu-bosa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/literata/scss/mixins.scss
+++ b/fonts/google/literata/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/liu-jian-mao-cao/scss/mixins.scss
+++ b/fonts/google/liu-jian-mao-cao/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/livvic/scss/mixins.scss
+++ b/fonts/google/livvic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lobster-two/scss/mixins.scss
+++ b/fonts/google/lobster-two/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lobster/scss/mixins.scss
+++ b/fonts/google/lobster/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/londrina-outline/scss/mixins.scss
+++ b/fonts/google/londrina-outline/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/londrina-shadow/scss/mixins.scss
+++ b/fonts/google/londrina-shadow/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/londrina-sketch/scss/mixins.scss
+++ b/fonts/google/londrina-sketch/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/londrina-solid/scss/mixins.scss
+++ b/fonts/google/londrina-solid/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/long-cang/scss/mixins.scss
+++ b/fonts/google/long-cang/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lora/scss/mixins.scss
+++ b/fonts/google/lora/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/love-light/scss/mixins.scss
+++ b/fonts/google/love-light/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/love-ya-like-a-sister/scss/mixins.scss
+++ b/fonts/google/love-ya-like-a-sister/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/loved-by-the-king/scss/mixins.scss
+++ b/fonts/google/loved-by-the-king/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lovers-quarrel/scss/mixins.scss
+++ b/fonts/google/lovers-quarrel/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/luckiest-guy/scss/mixins.scss
+++ b/fonts/google/luckiest-guy/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lugrasimo/scss/mixins.scss
+++ b/fonts/google/lugrasimo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lumanosimo/scss/mixins.scss
+++ b/fonts/google/lumanosimo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lunasima/scss/mixins.scss
+++ b/fonts/google/lunasima/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lusitana/scss/mixins.scss
+++ b/fonts/google/lusitana/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lustria/scss/mixins.scss
+++ b/fonts/google/lustria/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/luxurious-roman/scss/mixins.scss
+++ b/fonts/google/luxurious-roman/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/luxurious-script/scss/mixins.scss
+++ b/fonts/google/luxurious-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lxgw-wenkai-mono-tc/scss/mixins.scss
+++ b/fonts/google/lxgw-wenkai-mono-tc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/lxgw-wenkai-tc/scss/mixins.scss
+++ b/fonts/google/lxgw-wenkai-tc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/m-plus-1-code/scss/mixins.scss
+++ b/fonts/google/m-plus-1-code/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/m-plus-1/scss/mixins.scss
+++ b/fonts/google/m-plus-1/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/m-plus-1p/scss/mixins.scss
+++ b/fonts/google/m-plus-1p/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/m-plus-2/scss/mixins.scss
+++ b/fonts/google/m-plus-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/m-plus-code-latin/scss/mixins.scss
+++ b/fonts/google/m-plus-code-latin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/m-plus-rounded-1c/scss/mixins.scss
+++ b/fonts/google/m-plus-rounded-1c/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ma-shan-zheng/scss/mixins.scss
+++ b/fonts/google/ma-shan-zheng/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/macondo-swash-caps/scss/mixins.scss
+++ b/fonts/google/macondo-swash-caps/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/macondo/scss/mixins.scss
+++ b/fonts/google/macondo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mada/scss/mixins.scss
+++ b/fonts/google/mada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/madimi-one/scss/mixins.scss
+++ b/fonts/google/madimi-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/magra/scss/mixins.scss
+++ b/fonts/google/magra/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/maiden-orange/scss/mixins.scss
+++ b/fonts/google/maiden-orange/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/maitree/scss/mixins.scss
+++ b/fonts/google/maitree/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/major-mono-display/scss/mixins.scss
+++ b/fonts/google/major-mono-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mako/scss/mixins.scss
+++ b/fonts/google/mako/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mali/scss/mixins.scss
+++ b/fonts/google/mali/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mallanna/scss/mixins.scss
+++ b/fonts/google/mallanna/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/maname/scss/mixins.scss
+++ b/fonts/google/maname/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mandali/scss/mixins.scss
+++ b/fonts/google/mandali/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/manjari/scss/mixins.scss
+++ b/fonts/google/manjari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/manrope/scss/mixins.scss
+++ b/fonts/google/manrope/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mansalva/scss/mixins.scss
+++ b/fonts/google/mansalva/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/manuale/scss/mixins.scss
+++ b/fonts/google/manuale/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/marcellus-sc/scss/mixins.scss
+++ b/fonts/google/marcellus-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/marcellus/scss/mixins.scss
+++ b/fonts/google/marcellus/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/marck-script/scss/mixins.scss
+++ b/fonts/google/marck-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/margarine/scss/mixins.scss
+++ b/fonts/google/margarine/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/marhey/scss/mixins.scss
+++ b/fonts/google/marhey/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/markazi-text/scss/mixins.scss
+++ b/fonts/google/markazi-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/marko-one/scss/mixins.scss
+++ b/fonts/google/marko-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/marmelad/scss/mixins.scss
+++ b/fonts/google/marmelad/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/martel-sans/scss/mixins.scss
+++ b/fonts/google/martel-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/martel/scss/mixins.scss
+++ b/fonts/google/martel/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/martian-mono/scss/mixins.scss
+++ b/fonts/google/martian-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/marvel/scss/mixins.scss
+++ b/fonts/google/marvel/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mate-sc/scss/mixins.scss
+++ b/fonts/google/mate-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mate/scss/mixins.scss
+++ b/fonts/google/mate/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/matemasie/scss/mixins.scss
+++ b/fonts/google/matemasie/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/maven-pro/scss/mixins.scss
+++ b/fonts/google/maven-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mclaren/scss/mixins.scss
+++ b/fonts/google/mclaren/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mea-culpa/scss/mixins.scss
+++ b/fonts/google/mea-culpa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/meddon/scss/mixins.scss
+++ b/fonts/google/meddon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/medievalsharp/scss/mixins.scss
+++ b/fonts/google/medievalsharp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/medula-one/scss/mixins.scss
+++ b/fonts/google/medula-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/meera-inimai/scss/mixins.scss
+++ b/fonts/google/meera-inimai/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/megrim/scss/mixins.scss
+++ b/fonts/google/megrim/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/meie-script/scss/mixins.scss
+++ b/fonts/google/meie-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/meow-script/scss/mixins.scss
+++ b/fonts/google/meow-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/merienda-one/scss/mixins.scss
+++ b/fonts/google/merienda-one/scss/mixins.scss
@@ -84,7 +84,7 @@ $axes: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),
@@ -114,18 +114,18 @@ $axes: null !default;
 
                 font-family: string.quote($family),
                 font-style: if(
-                  ($axis == full or $axis == slnt) and map.has-key($metadata, axes, slnt), 
+                  ($axis == full or $axis == slnt) and map.has-key($metadata, axes, slnt),
                   oblique map.get($metadata, axes, slnt, min) + deg map.get($metadata, axes, slnt, max) + deg,
                   $style
                 ),
                 font-display: if($displayVar, var(--fontsource-display, $display), $display),
                 font-weight: if(
-                  ($axis == full or $axis == wght) and map.has-key($metadata, axes, wght), 
+                  ($axis == full or $axis == wght) and map.has-key($metadata, axes, wght),
                   map.get($metadata, axes, wght, min) map.get($metadata, axes, wght, max),
                   $weight
                 ),
                 font-stretch: if(
-                  ($axis == full or $axis == wdth) and map.has-key($metadata, axes, wdth), 
+                  ($axis == full or $axis == wdth) and map.has-key($metadata, axes, wdth),
                   '#{map.get($metadata, axes, wdth, min)}% #{map.get($metadata, axes, wdth, max)}%',
                   null
                 ),

--- a/fonts/google/merienda/scss/mixins.scss
+++ b/fonts/google/merienda/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/merriweather-sans/scss/mixins.scss
+++ b/fonts/google/merriweather-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/merriweather/scss/mixins.scss
+++ b/fonts/google/merriweather/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/metal-mania/scss/mixins.scss
+++ b/fonts/google/metal-mania/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/metal/scss/mixins.scss
+++ b/fonts/google/metal/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/metamorphous/scss/mixins.scss
+++ b/fonts/google/metamorphous/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/metrophobic/scss/mixins.scss
+++ b/fonts/google/metrophobic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/michroma/scss/mixins.scss
+++ b/fonts/google/michroma/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/micro-5-charted/scss/mixins.scss
+++ b/fonts/google/micro-5-charted/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/micro-5/scss/mixins.scss
+++ b/fonts/google/micro-5/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/milonga/scss/mixins.scss
+++ b/fonts/google/milonga/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/miltonian-tattoo/scss/mixins.scss
+++ b/fonts/google/miltonian-tattoo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/miltonian/scss/mixins.scss
+++ b/fonts/google/miltonian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mina/scss/mixins.scss
+++ b/fonts/google/mina/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mingzat/scss/mixins.scss
+++ b/fonts/google/mingzat/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/miniver/scss/mixins.scss
+++ b/fonts/google/miniver/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/miriam-libre/scss/mixins.scss
+++ b/fonts/google/miriam-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mirza/scss/mixins.scss
+++ b/fonts/google/mirza/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/miss-fajardose/scss/mixins.scss
+++ b/fonts/google/miss-fajardose/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mitr/scss/mixins.scss
+++ b/fonts/google/mitr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mochiy-pop-one/scss/mixins.scss
+++ b/fonts/google/mochiy-pop-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mochiy-pop-p-one/scss/mixins.scss
+++ b/fonts/google/mochiy-pop-p-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/modak/scss/mixins.scss
+++ b/fonts/google/modak/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/modern-antiqua/scss/mixins.scss
+++ b/fonts/google/modern-antiqua/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/moderustic/scss/mixins.scss
+++ b/fonts/google/moderustic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mogra/scss/mixins.scss
+++ b/fonts/google/mogra/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mohave/scss/mixins.scss
+++ b/fonts/google/mohave/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/moirai-one/scss/mixins.scss
+++ b/fonts/google/moirai-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/molengo/scss/mixins.scss
+++ b/fonts/google/molengo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/molle/scss/mixins.scss
+++ b/fonts/google/molle/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mona-sans/scss/mixins.scss
+++ b/fonts/google/mona-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/monda/scss/mixins.scss
+++ b/fonts/google/monda/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/monofett/scss/mixins.scss
+++ b/fonts/google/monofett/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/monomaniac-one/scss/mixins.scss
+++ b/fonts/google/monomaniac-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/monoton/scss/mixins.scss
+++ b/fonts/google/monoton/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/monsieur-la-doulaise/scss/mixins.scss
+++ b/fonts/google/monsieur-la-doulaise/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/montaga/scss/mixins.scss
+++ b/fonts/google/montaga/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/montagu-slab/scss/mixins.scss
+++ b/fonts/google/montagu-slab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/montecarlo/scss/mixins.scss
+++ b/fonts/google/montecarlo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/montez/scss/mixins.scss
+++ b/fonts/google/montez/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/montserrat-alternates/scss/mixins.scss
+++ b/fonts/google/montserrat-alternates/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/montserrat-subrayada/scss/mixins.scss
+++ b/fonts/google/montserrat-subrayada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/montserrat-underline/scss/mixins.scss
+++ b/fonts/google/montserrat-underline/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/montserrat/scss/mixins.scss
+++ b/fonts/google/montserrat/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/moo-lah-lah/scss/mixins.scss
+++ b/fonts/google/moo-lah-lah/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mooli/scss/mixins.scss
+++ b/fonts/google/mooli/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/moon-dance/scss/mixins.scss
+++ b/fonts/google/moon-dance/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/moul/scss/mixins.scss
+++ b/fonts/google/moul/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/moulpali/scss/mixins.scss
+++ b/fonts/google/moulpali/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mountains-of-christmas/scss/mixins.scss
+++ b/fonts/google/mountains-of-christmas/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mouse-memoirs/scss/mixins.scss
+++ b/fonts/google/mouse-memoirs/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mr-bedfort/scss/mixins.scss
+++ b/fonts/google/mr-bedfort/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mr-dafoe/scss/mixins.scss
+++ b/fonts/google/mr-dafoe/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mr-de-haviland/scss/mixins.scss
+++ b/fonts/google/mr-de-haviland/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mrs-saint-delafield/scss/mixins.scss
+++ b/fonts/google/mrs-saint-delafield/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mrs-sheppards/scss/mixins.scss
+++ b/fonts/google/mrs-sheppards/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ms-madi/scss/mixins.scss
+++ b/fonts/google/ms-madi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mukta-mahee/scss/mixins.scss
+++ b/fonts/google/mukta-mahee/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mukta-malar/scss/mixins.scss
+++ b/fonts/google/mukta-malar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mukta-vaani/scss/mixins.scss
+++ b/fonts/google/mukta-vaani/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mukta/scss/mixins.scss
+++ b/fonts/google/mukta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mulish/scss/mixins.scss
+++ b/fonts/google/mulish/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/murecho/scss/mixins.scss
+++ b/fonts/google/murecho/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/museomoderno/scss/mixins.scss
+++ b/fonts/google/museomoderno/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/my-soul/scss/mixins.scss
+++ b/fonts/google/my-soul/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mynerve/scss/mixins.scss
+++ b/fonts/google/mynerve/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/mystery-quest/scss/mixins.scss
+++ b/fonts/google/mystery-quest/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nabla/scss/mixins.scss
+++ b/fonts/google/nabla/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/namdhinggo/scss/mixins.scss
+++ b/fonts/google/namdhinggo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nanum-brush-script/scss/mixins.scss
+++ b/fonts/google/nanum-brush-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nanum-gothic-coding/scss/mixins.scss
+++ b/fonts/google/nanum-gothic-coding/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nanum-gothic/scss/mixins.scss
+++ b/fonts/google/nanum-gothic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nanum-myeongjo/scss/mixins.scss
+++ b/fonts/google/nanum-myeongjo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nanum-pen-script/scss/mixins.scss
+++ b/fonts/google/nanum-pen-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/narnoor/scss/mixins.scss
+++ b/fonts/google/narnoor/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/neonderthaw/scss/mixins.scss
+++ b/fonts/google/neonderthaw/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nerko-one/scss/mixins.scss
+++ b/fonts/google/nerko-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/neucha/scss/mixins.scss
+++ b/fonts/google/neucha/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/neuton/scss/mixins.scss
+++ b/fonts/google/neuton/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/new-amsterdam/scss/mixins.scss
+++ b/fonts/google/new-amsterdam/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/new-rocker/scss/mixins.scss
+++ b/fonts/google/new-rocker/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/new-tegomin/scss/mixins.scss
+++ b/fonts/google/new-tegomin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/news-cycle/scss/mixins.scss
+++ b/fonts/google/news-cycle/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/newsreader/scss/mixins.scss
+++ b/fonts/google/newsreader/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/niconne/scss/mixins.scss
+++ b/fonts/google/niconne/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/niramit/scss/mixins.scss
+++ b/fonts/google/niramit/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nixie-one/scss/mixins.scss
+++ b/fonts/google/nixie-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nobile/scss/mixins.scss
+++ b/fonts/google/nobile/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nokora/scss/mixins.scss
+++ b/fonts/google/nokora/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/norican/scss/mixins.scss
+++ b/fonts/google/norican/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nosifer/scss/mixins.scss
+++ b/fonts/google/nosifer/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/notable/scss/mixins.scss
+++ b/fonts/google/notable/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nothing-you-could-do/scss/mixins.scss
+++ b/fonts/google/nothing-you-could-do/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noticia-text/scss/mixins.scss
+++ b/fonts/google/noticia-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-color-emoji/scss/mixins.scss
+++ b/fonts/google/noto-color-emoji/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-emoji/scss/mixins.scss
+++ b/fonts/google/noto-emoji/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-kufi-arabic/scss/mixins.scss
+++ b/fonts/google/noto-kufi-arabic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-music/scss/mixins.scss
+++ b/fonts/google/noto-music/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-naskh-arabic/scss/mixins.scss
+++ b/fonts/google/noto-naskh-arabic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-nastaliq-urdu/scss/mixins.scss
+++ b/fonts/google/noto-nastaliq-urdu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-rashi-hebrew/scss/mixins.scss
+++ b/fonts/google/noto-rashi-hebrew/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-adlam-unjoined/scss/mixins.scss
+++ b/fonts/google/noto-sans-adlam-unjoined/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-adlam/scss/mixins.scss
+++ b/fonts/google/noto-sans-adlam/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-anatolian-hieroglyphs/scss/mixins.scss
+++ b/fonts/google/noto-sans-anatolian-hieroglyphs/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-arabic/scss/mixins.scss
+++ b/fonts/google/noto-sans-arabic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-armenian/scss/mixins.scss
+++ b/fonts/google/noto-sans-armenian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-avestan/scss/mixins.scss
+++ b/fonts/google/noto-sans-avestan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-balinese/scss/mixins.scss
+++ b/fonts/google/noto-sans-balinese/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-bamum/scss/mixins.scss
+++ b/fonts/google/noto-sans-bamum/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-bassa-vah/scss/mixins.scss
+++ b/fonts/google/noto-sans-bassa-vah/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-batak/scss/mixins.scss
+++ b/fonts/google/noto-sans-batak/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-bengali/scss/mixins.scss
+++ b/fonts/google/noto-sans-bengali/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-bhaiksuki/scss/mixins.scss
+++ b/fonts/google/noto-sans-bhaiksuki/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-brahmi/scss/mixins.scss
+++ b/fonts/google/noto-sans-brahmi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-buginese/scss/mixins.scss
+++ b/fonts/google/noto-sans-buginese/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-buhid/scss/mixins.scss
+++ b/fonts/google/noto-sans-buhid/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-canadian-aboriginal/scss/mixins.scss
+++ b/fonts/google/noto-sans-canadian-aboriginal/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-carian/scss/mixins.scss
+++ b/fonts/google/noto-sans-carian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-caucasian-albanian/scss/mixins.scss
+++ b/fonts/google/noto-sans-caucasian-albanian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-chakma/scss/mixins.scss
+++ b/fonts/google/noto-sans-chakma/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-cham/scss/mixins.scss
+++ b/fonts/google/noto-sans-cham/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-cherokee/scss/mixins.scss
+++ b/fonts/google/noto-sans-cherokee/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-chorasmian/scss/mixins.scss
+++ b/fonts/google/noto-sans-chorasmian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-coptic/scss/mixins.scss
+++ b/fonts/google/noto-sans-coptic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-cuneiform/scss/mixins.scss
+++ b/fonts/google/noto-sans-cuneiform/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-cypriot/scss/mixins.scss
+++ b/fonts/google/noto-sans-cypriot/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-cypro-minoan/scss/mixins.scss
+++ b/fonts/google/noto-sans-cypro-minoan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-deseret/scss/mixins.scss
+++ b/fonts/google/noto-sans-deseret/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-devanagari/scss/mixins.scss
+++ b/fonts/google/noto-sans-devanagari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-display/scss/mixins.scss
+++ b/fonts/google/noto-sans-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-duployan/scss/mixins.scss
+++ b/fonts/google/noto-sans-duployan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-egyptian-hieroglyphs/scss/mixins.scss
+++ b/fonts/google/noto-sans-egyptian-hieroglyphs/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-elbasan/scss/mixins.scss
+++ b/fonts/google/noto-sans-elbasan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-elymaic/scss/mixins.scss
+++ b/fonts/google/noto-sans-elymaic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-ethiopic/scss/mixins.scss
+++ b/fonts/google/noto-sans-ethiopic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-georgian/scss/mixins.scss
+++ b/fonts/google/noto-sans-georgian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-glagolitic/scss/mixins.scss
+++ b/fonts/google/noto-sans-glagolitic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-gothic/scss/mixins.scss
+++ b/fonts/google/noto-sans-gothic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-grantha/scss/mixins.scss
+++ b/fonts/google/noto-sans-grantha/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-gujarati/scss/mixins.scss
+++ b/fonts/google/noto-sans-gujarati/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-gunjala-gondi/scss/mixins.scss
+++ b/fonts/google/noto-sans-gunjala-gondi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-gurmukhi/scss/mixins.scss
+++ b/fonts/google/noto-sans-gurmukhi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-hanifi-rohingya/scss/mixins.scss
+++ b/fonts/google/noto-sans-hanifi-rohingya/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-hanunoo/scss/mixins.scss
+++ b/fonts/google/noto-sans-hanunoo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-hatran/scss/mixins.scss
+++ b/fonts/google/noto-sans-hatran/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-hebrew/scss/mixins.scss
+++ b/fonts/google/noto-sans-hebrew/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-hk/scss/mixins.scss
+++ b/fonts/google/noto-sans-hk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-imperial-aramaic/scss/mixins.scss
+++ b/fonts/google/noto-sans-imperial-aramaic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-indic-siyaq-numbers/scss/mixins.scss
+++ b/fonts/google/noto-sans-indic-siyaq-numbers/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-inscriptional-pahlavi/scss/mixins.scss
+++ b/fonts/google/noto-sans-inscriptional-pahlavi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-inscriptional-parthian/scss/mixins.scss
+++ b/fonts/google/noto-sans-inscriptional-parthian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-javanese/scss/mixins.scss
+++ b/fonts/google/noto-sans-javanese/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-jp/scss/mixins.scss
+++ b/fonts/google/noto-sans-jp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-kaithi/scss/mixins.scss
+++ b/fonts/google/noto-sans-kaithi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-kannada/scss/mixins.scss
+++ b/fonts/google/noto-sans-kannada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-kawi/scss/mixins.scss
+++ b/fonts/google/noto-sans-kawi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-kayah-li/scss/mixins.scss
+++ b/fonts/google/noto-sans-kayah-li/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-kharoshthi/scss/mixins.scss
+++ b/fonts/google/noto-sans-kharoshthi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-khmer/scss/mixins.scss
+++ b/fonts/google/noto-sans-khmer/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-khojki/scss/mixins.scss
+++ b/fonts/google/noto-sans-khojki/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-khudawadi/scss/mixins.scss
+++ b/fonts/google/noto-sans-khudawadi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-kr/scss/mixins.scss
+++ b/fonts/google/noto-sans-kr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-lao-looped/scss/mixins.scss
+++ b/fonts/google/noto-sans-lao-looped/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-lao/scss/mixins.scss
+++ b/fonts/google/noto-sans-lao/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-lepcha/scss/mixins.scss
+++ b/fonts/google/noto-sans-lepcha/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-limbu/scss/mixins.scss
+++ b/fonts/google/noto-sans-limbu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-linear-a/scss/mixins.scss
+++ b/fonts/google/noto-sans-linear-a/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-linear-b/scss/mixins.scss
+++ b/fonts/google/noto-sans-linear-b/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-lisu/scss/mixins.scss
+++ b/fonts/google/noto-sans-lisu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-lycian/scss/mixins.scss
+++ b/fonts/google/noto-sans-lycian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-lydian/scss/mixins.scss
+++ b/fonts/google/noto-sans-lydian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-mahajani/scss/mixins.scss
+++ b/fonts/google/noto-sans-mahajani/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-malayalam/scss/mixins.scss
+++ b/fonts/google/noto-sans-malayalam/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-mandaic/scss/mixins.scss
+++ b/fonts/google/noto-sans-mandaic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-manichaean/scss/mixins.scss
+++ b/fonts/google/noto-sans-manichaean/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-marchen/scss/mixins.scss
+++ b/fonts/google/noto-sans-marchen/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-masaram-gondi/scss/mixins.scss
+++ b/fonts/google/noto-sans-masaram-gondi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-math/scss/mixins.scss
+++ b/fonts/google/noto-sans-math/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-mayan-numerals/scss/mixins.scss
+++ b/fonts/google/noto-sans-mayan-numerals/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-medefaidrin/scss/mixins.scss
+++ b/fonts/google/noto-sans-medefaidrin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-meetei-mayek/scss/mixins.scss
+++ b/fonts/google/noto-sans-meetei-mayek/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-mende-kikakui/scss/mixins.scss
+++ b/fonts/google/noto-sans-mende-kikakui/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-meroitic/scss/mixins.scss
+++ b/fonts/google/noto-sans-meroitic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-miao/scss/mixins.scss
+++ b/fonts/google/noto-sans-miao/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-modi/scss/mixins.scss
+++ b/fonts/google/noto-sans-modi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-mongolian/scss/mixins.scss
+++ b/fonts/google/noto-sans-mongolian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-mono/scss/mixins.scss
+++ b/fonts/google/noto-sans-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-mro/scss/mixins.scss
+++ b/fonts/google/noto-sans-mro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-multani/scss/mixins.scss
+++ b/fonts/google/noto-sans-multani/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-myanmar/scss/mixins.scss
+++ b/fonts/google/noto-sans-myanmar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-nabataean/scss/mixins.scss
+++ b/fonts/google/noto-sans-nabataean/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-nag-mundari/scss/mixins.scss
+++ b/fonts/google/noto-sans-nag-mundari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-nandinagari/scss/mixins.scss
+++ b/fonts/google/noto-sans-nandinagari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-new-tai-lue/scss/mixins.scss
+++ b/fonts/google/noto-sans-new-tai-lue/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-newa/scss/mixins.scss
+++ b/fonts/google/noto-sans-newa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-nko-unjoined/scss/mixins.scss
+++ b/fonts/google/noto-sans-nko-unjoined/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-nko/scss/mixins.scss
+++ b/fonts/google/noto-sans-nko/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-nushu/scss/mixins.scss
+++ b/fonts/google/noto-sans-nushu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-ogham/scss/mixins.scss
+++ b/fonts/google/noto-sans-ogham/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-ol-chiki/scss/mixins.scss
+++ b/fonts/google/noto-sans-ol-chiki/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-old-hungarian/scss/mixins.scss
+++ b/fonts/google/noto-sans-old-hungarian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-old-italic/scss/mixins.scss
+++ b/fonts/google/noto-sans-old-italic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-old-north-arabian/scss/mixins.scss
+++ b/fonts/google/noto-sans-old-north-arabian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-old-permic/scss/mixins.scss
+++ b/fonts/google/noto-sans-old-permic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-old-persian/scss/mixins.scss
+++ b/fonts/google/noto-sans-old-persian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-old-sogdian/scss/mixins.scss
+++ b/fonts/google/noto-sans-old-sogdian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-old-south-arabian/scss/mixins.scss
+++ b/fonts/google/noto-sans-old-south-arabian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-old-turkic/scss/mixins.scss
+++ b/fonts/google/noto-sans-old-turkic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-oriya/scss/mixins.scss
+++ b/fonts/google/noto-sans-oriya/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-osage/scss/mixins.scss
+++ b/fonts/google/noto-sans-osage/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-osmanya/scss/mixins.scss
+++ b/fonts/google/noto-sans-osmanya/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-pahawh-hmong/scss/mixins.scss
+++ b/fonts/google/noto-sans-pahawh-hmong/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-palmyrene/scss/mixins.scss
+++ b/fonts/google/noto-sans-palmyrene/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-pau-cin-hau/scss/mixins.scss
+++ b/fonts/google/noto-sans-pau-cin-hau/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-phags-pa/scss/mixins.scss
+++ b/fonts/google/noto-sans-phags-pa/scss/mixins.scss
@@ -95,7 +95,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-phagspa/scss/mixins.scss
+++ b/fonts/google/noto-sans-phagspa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-phoenician/scss/mixins.scss
+++ b/fonts/google/noto-sans-phoenician/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-psalter-pahlavi/scss/mixins.scss
+++ b/fonts/google/noto-sans-psalter-pahlavi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-rejang/scss/mixins.scss
+++ b/fonts/google/noto-sans-rejang/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-runic/scss/mixins.scss
+++ b/fonts/google/noto-sans-runic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-samaritan/scss/mixins.scss
+++ b/fonts/google/noto-sans-samaritan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-saurashtra/scss/mixins.scss
+++ b/fonts/google/noto-sans-saurashtra/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-sc/scss/mixins.scss
+++ b/fonts/google/noto-sans-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-sharada/scss/mixins.scss
+++ b/fonts/google/noto-sans-sharada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-shavian/scss/mixins.scss
+++ b/fonts/google/noto-sans-shavian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-siddham/scss/mixins.scss
+++ b/fonts/google/noto-sans-siddham/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-signwriting/scss/mixins.scss
+++ b/fonts/google/noto-sans-signwriting/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-sinhala/scss/mixins.scss
+++ b/fonts/google/noto-sans-sinhala/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-sogdian/scss/mixins.scss
+++ b/fonts/google/noto-sans-sogdian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-sora-sompeng/scss/mixins.scss
+++ b/fonts/google/noto-sans-sora-sompeng/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-soyombo/scss/mixins.scss
+++ b/fonts/google/noto-sans-soyombo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-sundanese/scss/mixins.scss
+++ b/fonts/google/noto-sans-sundanese/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-syloti-nagri/scss/mixins.scss
+++ b/fonts/google/noto-sans-syloti-nagri/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-symbols-2/scss/mixins.scss
+++ b/fonts/google/noto-sans-symbols-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-symbols/scss/mixins.scss
+++ b/fonts/google/noto-sans-symbols/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-syriac-eastern/scss/mixins.scss
+++ b/fonts/google/noto-sans-syriac-eastern/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-syriac/scss/mixins.scss
+++ b/fonts/google/noto-sans-syriac/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-tagalog/scss/mixins.scss
+++ b/fonts/google/noto-sans-tagalog/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-tagbanwa/scss/mixins.scss
+++ b/fonts/google/noto-sans-tagbanwa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-tai-le/scss/mixins.scss
+++ b/fonts/google/noto-sans-tai-le/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-tai-tham/scss/mixins.scss
+++ b/fonts/google/noto-sans-tai-tham/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-tai-viet/scss/mixins.scss
+++ b/fonts/google/noto-sans-tai-viet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-takri/scss/mixins.scss
+++ b/fonts/google/noto-sans-takri/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-tamil-supplement/scss/mixins.scss
+++ b/fonts/google/noto-sans-tamil-supplement/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-tamil/scss/mixins.scss
+++ b/fonts/google/noto-sans-tamil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-tangsa/scss/mixins.scss
+++ b/fonts/google/noto-sans-tangsa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-tc/scss/mixins.scss
+++ b/fonts/google/noto-sans-tc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-telugu/scss/mixins.scss
+++ b/fonts/google/noto-sans-telugu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-thaana/scss/mixins.scss
+++ b/fonts/google/noto-sans-thaana/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-thai-looped/scss/mixins.scss
+++ b/fonts/google/noto-sans-thai-looped/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-thai/scss/mixins.scss
+++ b/fonts/google/noto-sans-thai/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-tifinagh/scss/mixins.scss
+++ b/fonts/google/noto-sans-tifinagh/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-tirhuta/scss/mixins.scss
+++ b/fonts/google/noto-sans-tirhuta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-ugaritic/scss/mixins.scss
+++ b/fonts/google/noto-sans-ugaritic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-vai/scss/mixins.scss
+++ b/fonts/google/noto-sans-vai/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-vithkuqi/scss/mixins.scss
+++ b/fonts/google/noto-sans-vithkuqi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-wancho/scss/mixins.scss
+++ b/fonts/google/noto-sans-wancho/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-warang-citi/scss/mixins.scss
+++ b/fonts/google/noto-sans-warang-citi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-yi/scss/mixins.scss
+++ b/fonts/google/noto-sans-yi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans-zanabazar-square/scss/mixins.scss
+++ b/fonts/google/noto-sans-zanabazar-square/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-sans/scss/mixins.scss
+++ b/fonts/google/noto-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-ahom/scss/mixins.scss
+++ b/fonts/google/noto-serif-ahom/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-armenian/scss/mixins.scss
+++ b/fonts/google/noto-serif-armenian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-balinese/scss/mixins.scss
+++ b/fonts/google/noto-serif-balinese/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-bengali/scss/mixins.scss
+++ b/fonts/google/noto-serif-bengali/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-devanagari/scss/mixins.scss
+++ b/fonts/google/noto-serif-devanagari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-display/scss/mixins.scss
+++ b/fonts/google/noto-serif-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-dogra/scss/mixins.scss
+++ b/fonts/google/noto-serif-dogra/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-ethiopic/scss/mixins.scss
+++ b/fonts/google/noto-serif-ethiopic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-georgian/scss/mixins.scss
+++ b/fonts/google/noto-serif-georgian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-grantha/scss/mixins.scss
+++ b/fonts/google/noto-serif-grantha/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-gujarati/scss/mixins.scss
+++ b/fonts/google/noto-serif-gujarati/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-gurmukhi/scss/mixins.scss
+++ b/fonts/google/noto-serif-gurmukhi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-hebrew/scss/mixins.scss
+++ b/fonts/google/noto-serif-hebrew/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-hk/scss/mixins.scss
+++ b/fonts/google/noto-serif-hk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-jp/scss/mixins.scss
+++ b/fonts/google/noto-serif-jp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-kannada/scss/mixins.scss
+++ b/fonts/google/noto-serif-kannada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-khitan-small-script/scss/mixins.scss
+++ b/fonts/google/noto-serif-khitan-small-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-khmer/scss/mixins.scss
+++ b/fonts/google/noto-serif-khmer/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-khojki/scss/mixins.scss
+++ b/fonts/google/noto-serif-khojki/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-kr/scss/mixins.scss
+++ b/fonts/google/noto-serif-kr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-lao/scss/mixins.scss
+++ b/fonts/google/noto-serif-lao/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-makasar/scss/mixins.scss
+++ b/fonts/google/noto-serif-makasar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-malayalam/scss/mixins.scss
+++ b/fonts/google/noto-serif-malayalam/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-myanmar/scss/mixins.scss
+++ b/fonts/google/noto-serif-myanmar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-np-hmong/scss/mixins.scss
+++ b/fonts/google/noto-serif-np-hmong/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-old-uyghur/scss/mixins.scss
+++ b/fonts/google/noto-serif-old-uyghur/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-oriya/scss/mixins.scss
+++ b/fonts/google/noto-serif-oriya/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-ottoman-siyaq/scss/mixins.scss
+++ b/fonts/google/noto-serif-ottoman-siyaq/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-sc/scss/mixins.scss
+++ b/fonts/google/noto-serif-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-sinhala/scss/mixins.scss
+++ b/fonts/google/noto-serif-sinhala/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-tamil/scss/mixins.scss
+++ b/fonts/google/noto-serif-tamil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-tangut/scss/mixins.scss
+++ b/fonts/google/noto-serif-tangut/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-tc/scss/mixins.scss
+++ b/fonts/google/noto-serif-tc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-telugu/scss/mixins.scss
+++ b/fonts/google/noto-serif-telugu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-thai/scss/mixins.scss
+++ b/fonts/google/noto-serif-thai/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-tibetan/scss/mixins.scss
+++ b/fonts/google/noto-serif-tibetan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-toto/scss/mixins.scss
+++ b/fonts/google/noto-serif-toto/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-vithkuqi/scss/mixins.scss
+++ b/fonts/google/noto-serif-vithkuqi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif-yezidi/scss/mixins.scss
+++ b/fonts/google/noto-serif-yezidi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-serif/scss/mixins.scss
+++ b/fonts/google/noto-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-traditional-nushu/scss/mixins.scss
+++ b/fonts/google/noto-traditional-nushu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/noto-znamenny-musical-notation/scss/mixins.scss
+++ b/fonts/google/noto-znamenny-musical-notation/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nova-cut/scss/mixins.scss
+++ b/fonts/google/nova-cut/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nova-flat/scss/mixins.scss
+++ b/fonts/google/nova-flat/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nova-mono/scss/mixins.scss
+++ b/fonts/google/nova-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nova-oval/scss/mixins.scss
+++ b/fonts/google/nova-oval/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nova-round/scss/mixins.scss
+++ b/fonts/google/nova-round/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nova-script/scss/mixins.scss
+++ b/fonts/google/nova-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nova-slim/scss/mixins.scss
+++ b/fonts/google/nova-slim/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nova-square/scss/mixins.scss
+++ b/fonts/google/nova-square/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ntr/scss/mixins.scss
+++ b/fonts/google/ntr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/numans/scss/mixins.scss
+++ b/fonts/google/numans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nunito-sans/scss/mixins.scss
+++ b/fonts/google/nunito-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nunito/scss/mixins.scss
+++ b/fonts/google/nunito/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/nuosu-sil/scss/mixins.scss
+++ b/fonts/google/nuosu-sil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/odibee-sans/scss/mixins.scss
+++ b/fonts/google/odibee-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/odor-mean-chey/scss/mixins.scss
+++ b/fonts/google/odor-mean-chey/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/offside/scss/mixins.scss
+++ b/fonts/google/offside/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/oi/scss/mixins.scss
+++ b/fonts/google/oi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ojuju/scss/mixins.scss
+++ b/fonts/google/ojuju/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/old-standard-tt/scss/mixins.scss
+++ b/fonts/google/old-standard-tt/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/oldenburg/scss/mixins.scss
+++ b/fonts/google/oldenburg/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ole/scss/mixins.scss
+++ b/fonts/google/ole/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/oleo-script-swash-caps/scss/mixins.scss
+++ b/fonts/google/oleo-script-swash-caps/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/oleo-script/scss/mixins.scss
+++ b/fonts/google/oleo-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/onest/scss/mixins.scss
+++ b/fonts/google/onest/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/oooh-baby/scss/mixins.scss
+++ b/fonts/google/oooh-baby/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/open-sans/scss/mixins.scss
+++ b/fonts/google/open-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/oranienbaum/scss/mixins.scss
+++ b/fonts/google/oranienbaum/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/orbit/scss/mixins.scss
+++ b/fonts/google/orbit/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/orbitron/scss/mixins.scss
+++ b/fonts/google/orbitron/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/oregano/scss/mixins.scss
+++ b/fonts/google/oregano/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/orelega-one/scss/mixins.scss
+++ b/fonts/google/orelega-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/orienta/scss/mixins.scss
+++ b/fonts/google/orienta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/original-surfer/scss/mixins.scss
+++ b/fonts/google/original-surfer/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/oswald/scss/mixins.scss
+++ b/fonts/google/oswald/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/outfit/scss/mixins.scss
+++ b/fonts/google/outfit/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/over-the-rainbow/scss/mixins.scss
+++ b/fonts/google/over-the-rainbow/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/overlock-sc/scss/mixins.scss
+++ b/fonts/google/overlock-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/overlock/scss/mixins.scss
+++ b/fonts/google/overlock/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/overpass-mono/scss/mixins.scss
+++ b/fonts/google/overpass-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/overpass/scss/mixins.scss
+++ b/fonts/google/overpass/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ovo/scss/mixins.scss
+++ b/fonts/google/ovo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/oxanium/scss/mixins.scss
+++ b/fonts/google/oxanium/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/oxygen-mono/scss/mixins.scss
+++ b/fonts/google/oxygen-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/oxygen/scss/mixins.scss
+++ b/fonts/google/oxygen/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pacifico/scss/mixins.scss
+++ b/fonts/google/pacifico/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/padauk/scss/mixins.scss
+++ b/fonts/google/padauk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/padyakke-expanded-one/scss/mixins.scss
+++ b/fonts/google/padyakke-expanded-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/palanquin-dark/scss/mixins.scss
+++ b/fonts/google/palanquin-dark/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/palanquin/scss/mixins.scss
+++ b/fonts/google/palanquin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/palette-mosaic/scss/mixins.scss
+++ b/fonts/google/palette-mosaic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pangolin/scss/mixins.scss
+++ b/fonts/google/pangolin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/paprika/scss/mixins.scss
+++ b/fonts/google/paprika/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/parisienne/scss/mixins.scss
+++ b/fonts/google/parisienne/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/parkinsans/scss/mixins.scss
+++ b/fonts/google/parkinsans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/passero-one/scss/mixins.scss
+++ b/fonts/google/passero-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/passion-one/scss/mixins.scss
+++ b/fonts/google/passion-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/passions-conflict/scss/mixins.scss
+++ b/fonts/google/passions-conflict/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pathway-extreme/scss/mixins.scss
+++ b/fonts/google/pathway-extreme/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pathway-gothic-one/scss/mixins.scss
+++ b/fonts/google/pathway-gothic-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/patrick-hand-sc/scss/mixins.scss
+++ b/fonts/google/patrick-hand-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/patrick-hand/scss/mixins.scss
+++ b/fonts/google/patrick-hand/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pattaya/scss/mixins.scss
+++ b/fonts/google/pattaya/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/patua-one/scss/mixins.scss
+++ b/fonts/google/patua-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pavanam/scss/mixins.scss
+++ b/fonts/google/pavanam/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/paytone-one/scss/mixins.scss
+++ b/fonts/google/paytone-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/peddana/scss/mixins.scss
+++ b/fonts/google/peddana/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/peralta/scss/mixins.scss
+++ b/fonts/google/peralta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/permanent-marker/scss/mixins.scss
+++ b/fonts/google/permanent-marker/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/petemoss/scss/mixins.scss
+++ b/fonts/google/petemoss/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/petit-formal-script/scss/mixins.scss
+++ b/fonts/google/petit-formal-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/petrona/scss/mixins.scss
+++ b/fonts/google/petrona/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/phetsarath/scss/mixins.scss
+++ b/fonts/google/phetsarath/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/philosopher/scss/mixins.scss
+++ b/fonts/google/philosopher/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/phudu/scss/mixins.scss
+++ b/fonts/google/phudu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/piazzolla/scss/mixins.scss
+++ b/fonts/google/piazzolla/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/piedra/scss/mixins.scss
+++ b/fonts/google/piedra/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pinyon-script/scss/mixins.scss
+++ b/fonts/google/pinyon-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pirata-one/scss/mixins.scss
+++ b/fonts/google/pirata-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pixelify-sans/scss/mixins.scss
+++ b/fonts/google/pixelify-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/plaster/scss/mixins.scss
+++ b/fonts/google/plaster/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/platypi/scss/mixins.scss
+++ b/fonts/google/platypi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/play/scss/mixins.scss
+++ b/fonts/google/play/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playball/scss/mixins.scss
+++ b/fonts/google/playball/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playfair-display-sc/scss/mixins.scss
+++ b/fonts/google/playfair-display-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playfair-display/scss/mixins.scss
+++ b/fonts/google/playfair-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playfair/scss/mixins.scss
+++ b/fonts/google/playfair/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playpen-sans/scss/mixins.scss
+++ b/fonts/google/playpen-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-ar-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-ar-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-ar/scss/mixins.scss
+++ b/fonts/google/playwrite-ar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-at-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-at-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-at/scss/mixins.scss
+++ b/fonts/google/playwrite-at/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-au-nsw-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-au-nsw-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-au-nsw/scss/mixins.scss
+++ b/fonts/google/playwrite-au-nsw/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-au-qld-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-au-qld-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-au-qld/scss/mixins.scss
+++ b/fonts/google/playwrite-au-qld/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-au-sa-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-au-sa-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-au-sa/scss/mixins.scss
+++ b/fonts/google/playwrite-au-sa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-au-tas-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-au-tas-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-au-tas/scss/mixins.scss
+++ b/fonts/google/playwrite-au-tas/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-au-vic-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-au-vic-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-au-vic/scss/mixins.scss
+++ b/fonts/google/playwrite-au-vic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-be-vlg-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-be-vlg-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-be-vlg/scss/mixins.scss
+++ b/fonts/google/playwrite-be-vlg/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-be-wal-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-be-wal-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-be-wal/scss/mixins.scss
+++ b/fonts/google/playwrite-be-wal/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-br-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-br-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-br/scss/mixins.scss
+++ b/fonts/google/playwrite-br/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-ca-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-ca-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-ca/scss/mixins.scss
+++ b/fonts/google/playwrite-ca/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-cl-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-cl-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-cl/scss/mixins.scss
+++ b/fonts/google/playwrite-cl/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-co-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-co-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-co/scss/mixins.scss
+++ b/fonts/google/playwrite-co/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-cu-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-cu-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-cu/scss/mixins.scss
+++ b/fonts/google/playwrite-cu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-cz-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-cz-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-cz/scss/mixins.scss
+++ b/fonts/google/playwrite-cz/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-de-grund-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-de-grund-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-de-grund/scss/mixins.scss
+++ b/fonts/google/playwrite-de-grund/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-de-la-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-de-la-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-de-la/scss/mixins.scss
+++ b/fonts/google/playwrite-de-la/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-de-sas-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-de-sas-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-de-sas/scss/mixins.scss
+++ b/fonts/google/playwrite-de-sas/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-de-va-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-de-va-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-de-va/scss/mixins.scss
+++ b/fonts/google/playwrite-de-va/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-dk-loopet-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-dk-loopet-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-dk-loopet/scss/mixins.scss
+++ b/fonts/google/playwrite-dk-loopet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-dk-uloopet-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-dk-uloopet-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-dk-uloopet/scss/mixins.scss
+++ b/fonts/google/playwrite-dk-uloopet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-es-deco-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-es-deco-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-es-deco/scss/mixins.scss
+++ b/fonts/google/playwrite-es-deco/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-es-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-es-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-es/scss/mixins.scss
+++ b/fonts/google/playwrite-es/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-fr-moderne-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-fr-moderne-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-fr-moderne/scss/mixins.scss
+++ b/fonts/google/playwrite-fr-moderne/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-fr-trad-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-fr-trad-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-fr-trad/scss/mixins.scss
+++ b/fonts/google/playwrite-fr-trad/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-gb-j-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-gb-j-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-gb-j/scss/mixins.scss
+++ b/fonts/google/playwrite-gb-j/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-gb-s-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-gb-s-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-gb-s/scss/mixins.scss
+++ b/fonts/google/playwrite-gb-s/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-hr-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-hr-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-hr-lijeva-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-hr-lijeva-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-hr-lijeva/scss/mixins.scss
+++ b/fonts/google/playwrite-hr-lijeva/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-hr/scss/mixins.scss
+++ b/fonts/google/playwrite-hr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-hu-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-hu-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-hu/scss/mixins.scss
+++ b/fonts/google/playwrite-hu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-id-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-id-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-id/scss/mixins.scss
+++ b/fonts/google/playwrite-id/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-ie-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-ie-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-ie/scss/mixins.scss
+++ b/fonts/google/playwrite-ie/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-in-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-in-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-in/scss/mixins.scss
+++ b/fonts/google/playwrite-in/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-is-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-is-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-is/scss/mixins.scss
+++ b/fonts/google/playwrite-is/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-it-moderna-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-it-moderna-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-it-moderna/scss/mixins.scss
+++ b/fonts/google/playwrite-it-moderna/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-it-trad-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-it-trad-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-it-trad/scss/mixins.scss
+++ b/fonts/google/playwrite-it-trad/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-mx-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-mx-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-mx/scss/mixins.scss
+++ b/fonts/google/playwrite-mx/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-ng-modern-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-ng-modern-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-ng-modern/scss/mixins.scss
+++ b/fonts/google/playwrite-ng-modern/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-nl-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-nl-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-nl/scss/mixins.scss
+++ b/fonts/google/playwrite-nl/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-no-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-no-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-no/scss/mixins.scss
+++ b/fonts/google/playwrite-no/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-nz-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-nz-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-nz/scss/mixins.scss
+++ b/fonts/google/playwrite-nz/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-pe-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-pe-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-pe/scss/mixins.scss
+++ b/fonts/google/playwrite-pe/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-pl-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-pl-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-pl/scss/mixins.scss
+++ b/fonts/google/playwrite-pl/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-pt-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-pt-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-pt/scss/mixins.scss
+++ b/fonts/google/playwrite-pt/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-ro-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-ro-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-ro/scss/mixins.scss
+++ b/fonts/google/playwrite-ro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-sk-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-sk-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-sk/scss/mixins.scss
+++ b/fonts/google/playwrite-sk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-tz-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-tz-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-tz/scss/mixins.scss
+++ b/fonts/google/playwrite-tz/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-us-modern-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-us-modern-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-us-modern/scss/mixins.scss
+++ b/fonts/google/playwrite-us-modern/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-us-trad-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-us-trad-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-us-trad/scss/mixins.scss
+++ b/fonts/google/playwrite-us-trad/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-vn-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-vn-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-vn/scss/mixins.scss
+++ b/fonts/google/playwrite-vn/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-za-guides/scss/mixins.scss
+++ b/fonts/google/playwrite-za-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/playwrite-za/scss/mixins.scss
+++ b/fonts/google/playwrite-za/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/plus-jakarta-sans/scss/mixins.scss
+++ b/fonts/google/plus-jakarta-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/podkova/scss/mixins.scss
+++ b/fonts/google/podkova/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/poetsen-one/scss/mixins.scss
+++ b/fonts/google/poetsen-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/poiret-one/scss/mixins.scss
+++ b/fonts/google/poiret-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/poller-one/scss/mixins.scss
+++ b/fonts/google/poller-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/poltawski-nowy/scss/mixins.scss
+++ b/fonts/google/poltawski-nowy/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/poly/scss/mixins.scss
+++ b/fonts/google/poly/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pompiere/scss/mixins.scss
+++ b/fonts/google/pompiere/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ponnala/scss/mixins.scss
+++ b/fonts/google/ponnala/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pontano-sans/scss/mixins.scss
+++ b/fonts/google/pontano-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/poor-story/scss/mixins.scss
+++ b/fonts/google/poor-story/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/poppins/scss/mixins.scss
+++ b/fonts/google/poppins/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/port-lligat-sans/scss/mixins.scss
+++ b/fonts/google/port-lligat-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/port-lligat-slab/scss/mixins.scss
+++ b/fonts/google/port-lligat-slab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/potta-one/scss/mixins.scss
+++ b/fonts/google/potta-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pragati-narrow/scss/mixins.scss
+++ b/fonts/google/pragati-narrow/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/praise/scss/mixins.scss
+++ b/fonts/google/praise/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/prata/scss/mixins.scss
+++ b/fonts/google/prata/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/preahvihear/scss/mixins.scss
+++ b/fonts/google/preahvihear/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/press-start-2p/scss/mixins.scss
+++ b/fonts/google/press-start-2p/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pridi/scss/mixins.scss
+++ b/fonts/google/pridi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/princess-sofia/scss/mixins.scss
+++ b/fonts/google/princess-sofia/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/prociono/scss/mixins.scss
+++ b/fonts/google/prociono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/prompt/scss/mixins.scss
+++ b/fonts/google/prompt/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/prosto-one/scss/mixins.scss
+++ b/fonts/google/prosto-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/protest-guerrilla/scss/mixins.scss
+++ b/fonts/google/protest-guerrilla/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/protest-revolution/scss/mixins.scss
+++ b/fonts/google/protest-revolution/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/protest-riot/scss/mixins.scss
+++ b/fonts/google/protest-riot/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/protest-strike/scss/mixins.scss
+++ b/fonts/google/protest-strike/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/proza-libre/scss/mixins.scss
+++ b/fonts/google/proza-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pt-mono/scss/mixins.scss
+++ b/fonts/google/pt-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pt-sans-caption/scss/mixins.scss
+++ b/fonts/google/pt-sans-caption/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pt-sans-narrow/scss/mixins.scss
+++ b/fonts/google/pt-sans-narrow/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pt-sans/scss/mixins.scss
+++ b/fonts/google/pt-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pt-serif-caption/scss/mixins.scss
+++ b/fonts/google/pt-serif-caption/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pt-serif/scss/mixins.scss
+++ b/fonts/google/pt-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/public-sans/scss/mixins.scss
+++ b/fonts/google/public-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/puppies-play/scss/mixins.scss
+++ b/fonts/google/puppies-play/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/puritan/scss/mixins.scss
+++ b/fonts/google/puritan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/purple-purse/scss/mixins.scss
+++ b/fonts/google/purple-purse/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/pushster/scss/mixins.scss
+++ b/fonts/google/pushster/scss/mixins.scss
@@ -87,7 +87,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/qahiri/scss/mixins.scss
+++ b/fonts/google/qahiri/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/quando/scss/mixins.scss
+++ b/fonts/google/quando/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/quantico/scss/mixins.scss
+++ b/fonts/google/quantico/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/quattrocento-sans/scss/mixins.scss
+++ b/fonts/google/quattrocento-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/quattrocento/scss/mixins.scss
+++ b/fonts/google/quattrocento/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/questrial/scss/mixins.scss
+++ b/fonts/google/questrial/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/quicksand/scss/mixins.scss
+++ b/fonts/google/quicksand/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/quintessential/scss/mixins.scss
+++ b/fonts/google/quintessential/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/qwigley/scss/mixins.scss
+++ b/fonts/google/qwigley/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/qwitcher-grypen/scss/mixins.scss
+++ b/fonts/google/qwitcher-grypen/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/racing-sans-one/scss/mixins.scss
+++ b/fonts/google/racing-sans-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/radio-canada-big/scss/mixins.scss
+++ b/fonts/google/radio-canada-big/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/radio-canada/scss/mixins.scss
+++ b/fonts/google/radio-canada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/radley/scss/mixins.scss
+++ b/fonts/google/radley/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rajdhani/scss/mixins.scss
+++ b/fonts/google/rajdhani/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rakkas/scss/mixins.scss
+++ b/fonts/google/rakkas/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/raleway-dots/scss/mixins.scss
+++ b/fonts/google/raleway-dots/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/raleway/scss/mixins.scss
+++ b/fonts/google/raleway/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ramabhadra/scss/mixins.scss
+++ b/fonts/google/ramabhadra/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ramaraja/scss/mixins.scss
+++ b/fonts/google/ramaraja/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rambla/scss/mixins.scss
+++ b/fonts/google/rambla/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rammetto-one/scss/mixins.scss
+++ b/fonts/google/rammetto-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rampart-one/scss/mixins.scss
+++ b/fonts/google/rampart-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ranchers/scss/mixins.scss
+++ b/fonts/google/ranchers/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rancho/scss/mixins.scss
+++ b/fonts/google/rancho/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ranga/scss/mixins.scss
+++ b/fonts/google/ranga/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rasa/scss/mixins.scss
+++ b/fonts/google/rasa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rationale/scss/mixins.scss
+++ b/fonts/google/rationale/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ravi-prakash/scss/mixins.scss
+++ b/fonts/google/ravi-prakash/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/readex-pro/scss/mixins.scss
+++ b/fonts/google/readex-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/recursive/scss/mixins.scss
+++ b/fonts/google/recursive/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/red-hat-display/scss/mixins.scss
+++ b/fonts/google/red-hat-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/red-hat-mono/scss/mixins.scss
+++ b/fonts/google/red-hat-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/red-hat-text/scss/mixins.scss
+++ b/fonts/google/red-hat-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/red-rose/scss/mixins.scss
+++ b/fonts/google/red-rose/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/redacted-script/scss/mixins.scss
+++ b/fonts/google/redacted-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/redacted/scss/mixins.scss
+++ b/fonts/google/redacted/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/reddit-mono/scss/mixins.scss
+++ b/fonts/google/reddit-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/reddit-sans-condensed/scss/mixins.scss
+++ b/fonts/google/reddit-sans-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/reddit-sans/scss/mixins.scss
+++ b/fonts/google/reddit-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/redressed/scss/mixins.scss
+++ b/fonts/google/redressed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/reem-kufi-fun/scss/mixins.scss
+++ b/fonts/google/reem-kufi-fun/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/reem-kufi-ink/scss/mixins.scss
+++ b/fonts/google/reem-kufi-ink/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/reem-kufi/scss/mixins.scss
+++ b/fonts/google/reem-kufi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/reenie-beanie/scss/mixins.scss
+++ b/fonts/google/reenie-beanie/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/reggae-one/scss/mixins.scss
+++ b/fonts/google/reggae-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rem/scss/mixins.scss
+++ b/fonts/google/rem/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rethink-sans/scss/mixins.scss
+++ b/fonts/google/rethink-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/revalia/scss/mixins.scss
+++ b/fonts/google/revalia/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rhodium-libre/scss/mixins.scss
+++ b/fonts/google/rhodium-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ribeye-marrow/scss/mixins.scss
+++ b/fonts/google/ribeye-marrow/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ribeye/scss/mixins.scss
+++ b/fonts/google/ribeye/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/righteous/scss/mixins.scss
+++ b/fonts/google/righteous/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/risque/scss/mixins.scss
+++ b/fonts/google/risque/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/road-rage/scss/mixins.scss
+++ b/fonts/google/road-rage/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/roboto-condensed/scss/mixins.scss
+++ b/fonts/google/roboto-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/roboto-flex/scss/mixins.scss
+++ b/fonts/google/roboto-flex/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/roboto-mono/scss/mixins.scss
+++ b/fonts/google/roboto-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/roboto-serif/scss/mixins.scss
+++ b/fonts/google/roboto-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/roboto-slab/scss/mixins.scss
+++ b/fonts/google/roboto-slab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/roboto/scss/mixins.scss
+++ b/fonts/google/roboto/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rochester/scss/mixins.scss
+++ b/fonts/google/rochester/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rock-3d/scss/mixins.scss
+++ b/fonts/google/rock-3d/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rock-salt/scss/mixins.scss
+++ b/fonts/google/rock-salt/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rocknroll-one/scss/mixins.scss
+++ b/fonts/google/rocknroll-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rokkitt/scss/mixins.scss
+++ b/fonts/google/rokkitt/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/romanesco/scss/mixins.scss
+++ b/fonts/google/romanesco/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ropa-sans/scss/mixins.scss
+++ b/fonts/google/ropa-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rosario/scss/mixins.scss
+++ b/fonts/google/rosario/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rosarivo/scss/mixins.scss
+++ b/fonts/google/rosarivo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rouge-script/scss/mixins.scss
+++ b/fonts/google/rouge-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rowdies/scss/mixins.scss
+++ b/fonts/google/rowdies/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rozha-one/scss/mixins.scss
+++ b/fonts/google/rozha-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-80s-fade/scss/mixins.scss
+++ b/fonts/google/rubik-80s-fade/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-beastly/scss/mixins.scss
+++ b/fonts/google/rubik-beastly/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-broken-fax/scss/mixins.scss
+++ b/fonts/google/rubik-broken-fax/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-bubbles/scss/mixins.scss
+++ b/fonts/google/rubik-bubbles/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-burned/scss/mixins.scss
+++ b/fonts/google/rubik-burned/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-dirt/scss/mixins.scss
+++ b/fonts/google/rubik-dirt/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-distressed/scss/mixins.scss
+++ b/fonts/google/rubik-distressed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-doodle-shadow/scss/mixins.scss
+++ b/fonts/google/rubik-doodle-shadow/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-doodle-triangles/scss/mixins.scss
+++ b/fonts/google/rubik-doodle-triangles/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-gemstones/scss/mixins.scss
+++ b/fonts/google/rubik-gemstones/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-glitch-pop/scss/mixins.scss
+++ b/fonts/google/rubik-glitch-pop/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-glitch/scss/mixins.scss
+++ b/fonts/google/rubik-glitch/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-iso/scss/mixins.scss
+++ b/fonts/google/rubik-iso/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-lines/scss/mixins.scss
+++ b/fonts/google/rubik-lines/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-maps/scss/mixins.scss
+++ b/fonts/google/rubik-maps/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-marker-hatch/scss/mixins.scss
+++ b/fonts/google/rubik-marker-hatch/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-maze/scss/mixins.scss
+++ b/fonts/google/rubik-maze/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-microbe/scss/mixins.scss
+++ b/fonts/google/rubik-microbe/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-mono-one/scss/mixins.scss
+++ b/fonts/google/rubik-mono-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-moonrocks/scss/mixins.scss
+++ b/fonts/google/rubik-moonrocks/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-pixels/scss/mixins.scss
+++ b/fonts/google/rubik-pixels/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-puddles/scss/mixins.scss
+++ b/fonts/google/rubik-puddles/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-scribble/scss/mixins.scss
+++ b/fonts/google/rubik-scribble/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-spray-paint/scss/mixins.scss
+++ b/fonts/google/rubik-spray-paint/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-storm/scss/mixins.scss
+++ b/fonts/google/rubik-storm/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-vinyl/scss/mixins.scss
+++ b/fonts/google/rubik-vinyl/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik-wet-paint/scss/mixins.scss
+++ b/fonts/google/rubik-wet-paint/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rubik/scss/mixins.scss
+++ b/fonts/google/rubik/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ruda/scss/mixins.scss
+++ b/fonts/google/ruda/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rufina/scss/mixins.scss
+++ b/fonts/google/rufina/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ruge-boogie/scss/mixins.scss
+++ b/fonts/google/ruge-boogie/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ruluko/scss/mixins.scss
+++ b/fonts/google/ruluko/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rum-raisin/scss/mixins.scss
+++ b/fonts/google/rum-raisin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ruslan-display/scss/mixins.scss
+++ b/fonts/google/ruslan-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/russo-one/scss/mixins.scss
+++ b/fonts/google/russo-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ruthie/scss/mixins.scss
+++ b/fonts/google/ruthie/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ruwudu/scss/mixins.scss
+++ b/fonts/google/ruwudu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/rye/scss/mixins.scss
+++ b/fonts/google/rye/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sacramento/scss/mixins.scss
+++ b/fonts/google/sacramento/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sahitya/scss/mixins.scss
+++ b/fonts/google/sahitya/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sail/scss/mixins.scss
+++ b/fonts/google/sail/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/saira-condensed/scss/mixins.scss
+++ b/fonts/google/saira-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/saira-extra-condensed/scss/mixins.scss
+++ b/fonts/google/saira-extra-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/saira-semi-condensed/scss/mixins.scss
+++ b/fonts/google/saira-semi-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/saira-stencil-one/scss/mixins.scss
+++ b/fonts/google/saira-stencil-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/saira/scss/mixins.scss
+++ b/fonts/google/saira/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/salsa/scss/mixins.scss
+++ b/fonts/google/salsa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sanchez/scss/mixins.scss
+++ b/fonts/google/sanchez/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sancreek/scss/mixins.scss
+++ b/fonts/google/sancreek/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sankofa-display/scss/mixins.scss
+++ b/fonts/google/sankofa-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sansita-swashed/scss/mixins.scss
+++ b/fonts/google/sansita-swashed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sansita/scss/mixins.scss
+++ b/fonts/google/sansita/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sarabun/scss/mixins.scss
+++ b/fonts/google/sarabun/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sarala/scss/mixins.scss
+++ b/fonts/google/sarala/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sarina/scss/mixins.scss
+++ b/fonts/google/sarina/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sarpanch/scss/mixins.scss
+++ b/fonts/google/sarpanch/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sassy-frass/scss/mixins.scss
+++ b/fonts/google/sassy-frass/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/satisfy/scss/mixins.scss
+++ b/fonts/google/satisfy/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sawarabi-gothic/scss/mixins.scss
+++ b/fonts/google/sawarabi-gothic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sawarabi-mincho/scss/mixins.scss
+++ b/fonts/google/sawarabi-mincho/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/scada/scss/mixins.scss
+++ b/fonts/google/scada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/scheherazade-new/scss/mixins.scss
+++ b/fonts/google/scheherazade-new/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/schibsted-grotesk/scss/mixins.scss
+++ b/fonts/google/schibsted-grotesk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/schoolbell/scss/mixins.scss
+++ b/fonts/google/schoolbell/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/scope-one/scss/mixins.scss
+++ b/fonts/google/scope-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/seaweed-script/scss/mixins.scss
+++ b/fonts/google/seaweed-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/secular-one/scss/mixins.scss
+++ b/fonts/google/secular-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sedan-sc/scss/mixins.scss
+++ b/fonts/google/sedan-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sedan/scss/mixins.scss
+++ b/fonts/google/sedan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sedgwick-ave-display/scss/mixins.scss
+++ b/fonts/google/sedgwick-ave-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sedgwick-ave/scss/mixins.scss
+++ b/fonts/google/sedgwick-ave/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sen/scss/mixins.scss
+++ b/fonts/google/sen/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/send-flowers/scss/mixins.scss
+++ b/fonts/google/send-flowers/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sevillana/scss/mixins.scss
+++ b/fonts/google/sevillana/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/seymour-one/scss/mixins.scss
+++ b/fonts/google/seymour-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/shadows-into-light-two/scss/mixins.scss
+++ b/fonts/google/shadows-into-light-two/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/shadows-into-light/scss/mixins.scss
+++ b/fonts/google/shadows-into-light/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/shalimar/scss/mixins.scss
+++ b/fonts/google/shalimar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/shantell-sans/scss/mixins.scss
+++ b/fonts/google/shantell-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/shanti/scss/mixins.scss
+++ b/fonts/google/shanti/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/share-tech-mono/scss/mixins.scss
+++ b/fonts/google/share-tech-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/share-tech/scss/mixins.scss
+++ b/fonts/google/share-tech/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/share/scss/mixins.scss
+++ b/fonts/google/share/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/shippori-antique-b1/scss/mixins.scss
+++ b/fonts/google/shippori-antique-b1/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/shippori-antique/scss/mixins.scss
+++ b/fonts/google/shippori-antique/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/shippori-mincho-b1/scss/mixins.scss
+++ b/fonts/google/shippori-mincho-b1/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/shippori-mincho/scss/mixins.scss
+++ b/fonts/google/shippori-mincho/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/shizuru/scss/mixins.scss
+++ b/fonts/google/shizuru/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/shojumaru/scss/mixins.scss
+++ b/fonts/google/shojumaru/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/short-stack/scss/mixins.scss
+++ b/fonts/google/short-stack/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/shrikhand/scss/mixins.scss
+++ b/fonts/google/shrikhand/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/siemreap/scss/mixins.scss
+++ b/fonts/google/siemreap/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sigmar-one/scss/mixins.scss
+++ b/fonts/google/sigmar-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sigmar/scss/mixins.scss
+++ b/fonts/google/sigmar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/signika-negative/scss/mixins.scss
+++ b/fonts/google/signika-negative/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/signika/scss/mixins.scss
+++ b/fonts/google/signika/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/silkscreen/scss/mixins.scss
+++ b/fonts/google/silkscreen/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/simonetta/scss/mixins.scss
+++ b/fonts/google/simonetta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/single-day/scss/mixins.scss
+++ b/fonts/google/single-day/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sintony/scss/mixins.scss
+++ b/fonts/google/sintony/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sirin-stencil/scss/mixins.scss
+++ b/fonts/google/sirin-stencil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/six-caps/scss/mixins.scss
+++ b/fonts/google/six-caps/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sixtyfour-convergence/scss/mixins.scss
+++ b/fonts/google/sixtyfour-convergence/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sixtyfour/scss/mixins.scss
+++ b/fonts/google/sixtyfour/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/skranji/scss/mixins.scss
+++ b/fonts/google/skranji/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/slabo-13px/scss/mixins.scss
+++ b/fonts/google/slabo-13px/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/slabo-27px/scss/mixins.scss
+++ b/fonts/google/slabo-27px/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/slackey/scss/mixins.scss
+++ b/fonts/google/slackey/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/slackside-one/scss/mixins.scss
+++ b/fonts/google/slackside-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/smokum/scss/mixins.scss
+++ b/fonts/google/smokum/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/smooch-sans/scss/mixins.scss
+++ b/fonts/google/smooch-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/smooch/scss/mixins.scss
+++ b/fonts/google/smooch/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/smythe/scss/mixins.scss
+++ b/fonts/google/smythe/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sniglet/scss/mixins.scss
+++ b/fonts/google/sniglet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/snippet/scss/mixins.scss
+++ b/fonts/google/snippet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/snowburst-one/scss/mixins.scss
+++ b/fonts/google/snowburst-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sofadi-one/scss/mixins.scss
+++ b/fonts/google/sofadi-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sofia-sans-condensed/scss/mixins.scss
+++ b/fonts/google/sofia-sans-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sofia-sans-extra-condensed/scss/mixins.scss
+++ b/fonts/google/sofia-sans-extra-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sofia-sans-semi-condensed/scss/mixins.scss
+++ b/fonts/google/sofia-sans-semi-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sofia-sans/scss/mixins.scss
+++ b/fonts/google/sofia-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sofia/scss/mixins.scss
+++ b/fonts/google/sofia/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/solitreo/scss/mixins.scss
+++ b/fonts/google/solitreo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/solway/scss/mixins.scss
+++ b/fonts/google/solway/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sometype-mono/scss/mixins.scss
+++ b/fonts/google/sometype-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/song-myung/scss/mixins.scss
+++ b/fonts/google/song-myung/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sono/scss/mixins.scss
+++ b/fonts/google/sono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sonsie-one/scss/mixins.scss
+++ b/fonts/google/sonsie-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sora/scss/mixins.scss
+++ b/fonts/google/sora/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sorts-mill-goudy/scss/mixins.scss
+++ b/fonts/google/sorts-mill-goudy/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sour-gummy/scss/mixins.scss
+++ b/fonts/google/sour-gummy/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/source-code-pro/scss/mixins.scss
+++ b/fonts/google/source-code-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/source-sans-3/scss/mixins.scss
+++ b/fonts/google/source-sans-3/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/source-sans-pro/scss/mixins.scss
+++ b/fonts/google/source-sans-pro/scss/mixins.scss
@@ -87,7 +87,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/source-serif-4/scss/mixins.scss
+++ b/fonts/google/source-serif-4/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/source-serif-pro/scss/mixins.scss
+++ b/fonts/google/source-serif-pro/scss/mixins.scss
@@ -87,7 +87,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/space-grotesk/scss/mixins.scss
+++ b/fonts/google/space-grotesk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/space-mono/scss/mixins.scss
+++ b/fonts/google/space-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/special-elite/scss/mixins.scss
+++ b/fonts/google/special-elite/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/spectral-sc/scss/mixins.scss
+++ b/fonts/google/spectral-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/spectral/scss/mixins.scss
+++ b/fonts/google/spectral/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/spicy-rice/scss/mixins.scss
+++ b/fonts/google/spicy-rice/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/spinnaker/scss/mixins.scss
+++ b/fonts/google/spinnaker/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/spirax/scss/mixins.scss
+++ b/fonts/google/spirax/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/splash/scss/mixins.scss
+++ b/fonts/google/splash/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/spline-sans-mono/scss/mixins.scss
+++ b/fonts/google/spline-sans-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/spline-sans/scss/mixins.scss
+++ b/fonts/google/spline-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/squada-one/scss/mixins.scss
+++ b/fonts/google/squada-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/square-peg/scss/mixins.scss
+++ b/fonts/google/square-peg/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sree-krushnadevaraya/scss/mixins.scss
+++ b/fonts/google/sree-krushnadevaraya/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sriracha/scss/mixins.scss
+++ b/fonts/google/sriracha/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/srisakdi/scss/mixins.scss
+++ b/fonts/google/srisakdi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/staatliches/scss/mixins.scss
+++ b/fonts/google/staatliches/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/stalemate/scss/mixins.scss
+++ b/fonts/google/stalemate/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/stalinist-one/scss/mixins.scss
+++ b/fonts/google/stalinist-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/stardos-stencil/scss/mixins.scss
+++ b/fonts/google/stardos-stencil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/stick-no-bills/scss/mixins.scss
+++ b/fonts/google/stick-no-bills/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/stick/scss/mixins.scss
+++ b/fonts/google/stick/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/stint-ultra-condensed/scss/mixins.scss
+++ b/fonts/google/stint-ultra-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/stint-ultra-expanded/scss/mixins.scss
+++ b/fonts/google/stint-ultra-expanded/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/stix-two-text/scss/mixins.scss
+++ b/fonts/google/stix-two-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/stoke/scss/mixins.scss
+++ b/fonts/google/stoke/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/strait/scss/mixins.scss
+++ b/fonts/google/strait/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/style-script/scss/mixins.scss
+++ b/fonts/google/style-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/stylish/scss/mixins.scss
+++ b/fonts/google/stylish/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sue-ellen-francisco/scss/mixins.scss
+++ b/fonts/google/sue-ellen-francisco/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/suez-one/scss/mixins.scss
+++ b/fonts/google/suez-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sulphur-point/scss/mixins.scss
+++ b/fonts/google/sulphur-point/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sumana/scss/mixins.scss
+++ b/fonts/google/sumana/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sunflower/scss/mixins.scss
+++ b/fonts/google/sunflower/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sunshiney/scss/mixins.scss
+++ b/fonts/google/sunshiney/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/supermercado-one/scss/mixins.scss
+++ b/fonts/google/supermercado-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/sura/scss/mixins.scss
+++ b/fonts/google/sura/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/suranna/scss/mixins.scss
+++ b/fonts/google/suranna/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/suravaram/scss/mixins.scss
+++ b/fonts/google/suravaram/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/suse/scss/mixins.scss
+++ b/fonts/google/suse/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/suwannaphum/scss/mixins.scss
+++ b/fonts/google/suwannaphum/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/swanky-and-moo-moo/scss/mixins.scss
+++ b/fonts/google/swanky-and-moo-moo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/syncopate/scss/mixins.scss
+++ b/fonts/google/syncopate/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/syne-mono/scss/mixins.scss
+++ b/fonts/google/syne-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/syne-tactile/scss/mixins.scss
+++ b/fonts/google/syne-tactile/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/syne/scss/mixins.scss
+++ b/fonts/google/syne/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tac-one/scss/mixins.scss
+++ b/fonts/google/tac-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tai-heritage-pro/scss/mixins.scss
+++ b/fonts/google/tai-heritage-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tajawal/scss/mixins.scss
+++ b/fonts/google/tajawal/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tangerine/scss/mixins.scss
+++ b/fonts/google/tangerine/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tapestry/scss/mixins.scss
+++ b/fonts/google/tapestry/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/taprom/scss/mixins.scss
+++ b/fonts/google/taprom/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tauri/scss/mixins.scss
+++ b/fonts/google/tauri/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/taviraj/scss/mixins.scss
+++ b/fonts/google/taviraj/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/teachers/scss/mixins.scss
+++ b/fonts/google/teachers/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/teko/scss/mixins.scss
+++ b/fonts/google/teko/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tektur/scss/mixins.scss
+++ b/fonts/google/tektur/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/telex/scss/mixins.scss
+++ b/fonts/google/telex/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tenali-ramakrishna/scss/mixins.scss
+++ b/fonts/google/tenali-ramakrishna/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tenor-sans/scss/mixins.scss
+++ b/fonts/google/tenor-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/text-me-one/scss/mixins.scss
+++ b/fonts/google/text-me-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/texturina/scss/mixins.scss
+++ b/fonts/google/texturina/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/thasadith/scss/mixins.scss
+++ b/fonts/google/thasadith/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/the-girl-next-door/scss/mixins.scss
+++ b/fonts/google/the-girl-next-door/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/the-nautigal/scss/mixins.scss
+++ b/fonts/google/the-nautigal/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tienne/scss/mixins.scss
+++ b/fonts/google/tienne/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tillana/scss/mixins.scss
+++ b/fonts/google/tillana/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tilt-neon/scss/mixins.scss
+++ b/fonts/google/tilt-neon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tilt-prism/scss/mixins.scss
+++ b/fonts/google/tilt-prism/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tilt-warp/scss/mixins.scss
+++ b/fonts/google/tilt-warp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/timmana/scss/mixins.scss
+++ b/fonts/google/timmana/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tinos/scss/mixins.scss
+++ b/fonts/google/tinos/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tiny5/scss/mixins.scss
+++ b/fonts/google/tiny5/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tiro-bangla/scss/mixins.scss
+++ b/fonts/google/tiro-bangla/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tiro-devanagari-hindi/scss/mixins.scss
+++ b/fonts/google/tiro-devanagari-hindi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tiro-devanagari-marathi/scss/mixins.scss
+++ b/fonts/google/tiro-devanagari-marathi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tiro-devanagari-sanskrit/scss/mixins.scss
+++ b/fonts/google/tiro-devanagari-sanskrit/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tiro-gurmukhi/scss/mixins.scss
+++ b/fonts/google/tiro-gurmukhi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tiro-kannada/scss/mixins.scss
+++ b/fonts/google/tiro-kannada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tiro-tamil/scss/mixins.scss
+++ b/fonts/google/tiro-tamil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tiro-telugu/scss/mixins.scss
+++ b/fonts/google/tiro-telugu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/titan-one/scss/mixins.scss
+++ b/fonts/google/titan-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/titillium-web/scss/mixins.scss
+++ b/fonts/google/titillium-web/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tomorrow/scss/mixins.scss
+++ b/fonts/google/tomorrow/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tourney/scss/mixins.scss
+++ b/fonts/google/tourney/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/trade-winds/scss/mixins.scss
+++ b/fonts/google/trade-winds/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/train-one/scss/mixins.scss
+++ b/fonts/google/train-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/trirong/scss/mixins.scss
+++ b/fonts/google/trirong/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/trispace/scss/mixins.scss
+++ b/fonts/google/trispace/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/trocchi/scss/mixins.scss
+++ b/fonts/google/trocchi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/trochut/scss/mixins.scss
+++ b/fonts/google/trochut/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/truculenta/scss/mixins.scss
+++ b/fonts/google/truculenta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/trykker/scss/mixins.scss
+++ b/fonts/google/trykker/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tsukimi-rounded/scss/mixins.scss
+++ b/fonts/google/tsukimi-rounded/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/tulpen-one/scss/mixins.scss
+++ b/fonts/google/tulpen-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/turret-road/scss/mixins.scss
+++ b/fonts/google/turret-road/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/twinkle-star/scss/mixins.scss
+++ b/fonts/google/twinkle-star/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ubuntu-condensed/scss/mixins.scss
+++ b/fonts/google/ubuntu-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ubuntu-mono/scss/mixins.scss
+++ b/fonts/google/ubuntu-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ubuntu-sans-mono/scss/mixins.scss
+++ b/fonts/google/ubuntu-sans-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ubuntu-sans/scss/mixins.scss
+++ b/fonts/google/ubuntu-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ubuntu/scss/mixins.scss
+++ b/fonts/google/ubuntu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/uchen/scss/mixins.scss
+++ b/fonts/google/uchen/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ultra/scss/mixins.scss
+++ b/fonts/google/ultra/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/unbounded/scss/mixins.scss
+++ b/fonts/google/unbounded/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/uncial-antiqua/scss/mixins.scss
+++ b/fonts/google/uncial-antiqua/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/underdog/scss/mixins.scss
+++ b/fonts/google/underdog/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/unica-one/scss/mixins.scss
+++ b/fonts/google/unica-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/unifrakturcook/scss/mixins.scss
+++ b/fonts/google/unifrakturcook/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/unifrakturmaguntia/scss/mixins.scss
+++ b/fonts/google/unifrakturmaguntia/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/unkempt/scss/mixins.scss
+++ b/fonts/google/unkempt/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/unlock/scss/mixins.scss
+++ b/fonts/google/unlock/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/unna/scss/mixins.scss
+++ b/fonts/google/unna/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/updock/scss/mixins.scss
+++ b/fonts/google/updock/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/urbanist/scss/mixins.scss
+++ b/fonts/google/urbanist/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/vampiro-one/scss/mixins.scss
+++ b/fonts/google/vampiro-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/varela-round/scss/mixins.scss
+++ b/fonts/google/varela-round/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/varela/scss/mixins.scss
+++ b/fonts/google/varela/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/varta/scss/mixins.scss
+++ b/fonts/google/varta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/vast-shadow/scss/mixins.scss
+++ b/fonts/google/vast-shadow/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/vazirmatn/scss/mixins.scss
+++ b/fonts/google/vazirmatn/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/vesper-libre/scss/mixins.scss
+++ b/fonts/google/vesper-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/viaoda-libre/scss/mixins.scss
+++ b/fonts/google/viaoda-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/vibes/scss/mixins.scss
+++ b/fonts/google/vibes/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/vibur/scss/mixins.scss
+++ b/fonts/google/vibur/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/victor-mono/scss/mixins.scss
+++ b/fonts/google/victor-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/vidaloka/scss/mixins.scss
+++ b/fonts/google/vidaloka/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/viga/scss/mixins.scss
+++ b/fonts/google/viga/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/vina-sans/scss/mixins.scss
+++ b/fonts/google/vina-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/voces/scss/mixins.scss
+++ b/fonts/google/voces/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/volkhov/scss/mixins.scss
+++ b/fonts/google/volkhov/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/vollkorn-sc/scss/mixins.scss
+++ b/fonts/google/vollkorn-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/vollkorn/scss/mixins.scss
+++ b/fonts/google/vollkorn/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/voltaire/scss/mixins.scss
+++ b/fonts/google/voltaire/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/vt323/scss/mixins.scss
+++ b/fonts/google/vt323/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/vujahday-script/scss/mixins.scss
+++ b/fonts/google/vujahday-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/waiting-for-the-sunrise/scss/mixins.scss
+++ b/fonts/google/waiting-for-the-sunrise/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/wallpoet/scss/mixins.scss
+++ b/fonts/google/wallpoet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/walter-turncoat/scss/mixins.scss
+++ b/fonts/google/walter-turncoat/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/warnes/scss/mixins.scss
+++ b/fonts/google/warnes/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/water-brush/scss/mixins.scss
+++ b/fonts/google/water-brush/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/waterfall/scss/mixins.scss
+++ b/fonts/google/waterfall/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/wavefont/scss/mixins.scss
+++ b/fonts/google/wavefont/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/wellfleet/scss/mixins.scss
+++ b/fonts/google/wellfleet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/wendy-one/scss/mixins.scss
+++ b/fonts/google/wendy-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/whisper/scss/mixins.scss
+++ b/fonts/google/whisper/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/windsong/scss/mixins.scss
+++ b/fonts/google/windsong/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/wire-one/scss/mixins.scss
+++ b/fonts/google/wire-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/wittgenstein/scss/mixins.scss
+++ b/fonts/google/wittgenstein/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/wix-madefor-display/scss/mixins.scss
+++ b/fonts/google/wix-madefor-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/wix-madefor-text/scss/mixins.scss
+++ b/fonts/google/wix-madefor-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/work-sans/scss/mixins.scss
+++ b/fonts/google/work-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/workbench/scss/mixins.scss
+++ b/fonts/google/workbench/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/xanh-mono/scss/mixins.scss
+++ b/fonts/google/xanh-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yaldevi/scss/mixins.scss
+++ b/fonts/google/yaldevi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yanone-kaffeesatz/scss/mixins.scss
+++ b/fonts/google/yanone-kaffeesatz/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yantramanav/scss/mixins.scss
+++ b/fonts/google/yantramanav/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yarndings-12-charted/scss/mixins.scss
+++ b/fonts/google/yarndings-12-charted/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yarndings-12/scss/mixins.scss
+++ b/fonts/google/yarndings-12/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yarndings-20-charted/scss/mixins.scss
+++ b/fonts/google/yarndings-20-charted/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yarndings-20/scss/mixins.scss
+++ b/fonts/google/yarndings-20/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yatra-one/scss/mixins.scss
+++ b/fonts/google/yatra-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yellowtail/scss/mixins.scss
+++ b/fonts/google/yellowtail/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yeon-sung/scss/mixins.scss
+++ b/fonts/google/yeon-sung/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yeseva-one/scss/mixins.scss
+++ b/fonts/google/yeseva-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yesteryear/scss/mixins.scss
+++ b/fonts/google/yesteryear/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yomogi/scss/mixins.scss
+++ b/fonts/google/yomogi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/young-serif/scss/mixins.scss
+++ b/fonts/google/young-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yrsa/scss/mixins.scss
+++ b/fonts/google/yrsa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ysabeau-infant/scss/mixins.scss
+++ b/fonts/google/ysabeau-infant/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ysabeau-office/scss/mixins.scss
+++ b/fonts/google/ysabeau-office/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ysabeau-sc/scss/mixins.scss
+++ b/fonts/google/ysabeau-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/ysabeau/scss/mixins.scss
+++ b/fonts/google/ysabeau/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yuji-boku/scss/mixins.scss
+++ b/fonts/google/yuji-boku/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yuji-hentaigana-akari/scss/mixins.scss
+++ b/fonts/google/yuji-hentaigana-akari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yuji-hentaigana-akebono/scss/mixins.scss
+++ b/fonts/google/yuji-hentaigana-akebono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yuji-mai/scss/mixins.scss
+++ b/fonts/google/yuji-mai/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yuji-syuku/scss/mixins.scss
+++ b/fonts/google/yuji-syuku/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/yusei-magic/scss/mixins.scss
+++ b/fonts/google/yusei-magic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zain/scss/mixins.scss
+++ b/fonts/google/zain/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zcool-kuaile/scss/mixins.scss
+++ b/fonts/google/zcool-kuaile/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zcool-qingke-huangyou/scss/mixins.scss
+++ b/fonts/google/zcool-qingke-huangyou/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zcool-xiaowei/scss/mixins.scss
+++ b/fonts/google/zcool-xiaowei/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zen-antique-soft/scss/mixins.scss
+++ b/fonts/google/zen-antique-soft/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zen-antique/scss/mixins.scss
+++ b/fonts/google/zen-antique/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zen-dots/scss/mixins.scss
+++ b/fonts/google/zen-dots/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zen-kaku-gothic-antique/scss/mixins.scss
+++ b/fonts/google/zen-kaku-gothic-antique/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zen-kaku-gothic-new/scss/mixins.scss
+++ b/fonts/google/zen-kaku-gothic-new/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zen-kurenaido/scss/mixins.scss
+++ b/fonts/google/zen-kurenaido/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zen-loop/scss/mixins.scss
+++ b/fonts/google/zen-loop/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zen-maru-gothic/scss/mixins.scss
+++ b/fonts/google/zen-maru-gothic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zen-old-mincho/scss/mixins.scss
+++ b/fonts/google/zen-old-mincho/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zen-tokyo-zoo/scss/mixins.scss
+++ b/fonts/google/zen-tokyo-zoo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zeyada/scss/mixins.scss
+++ b/fonts/google/zeyada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zhi-mang-xing/scss/mixins.scss
+++ b/fonts/google/zhi-mang-xing/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zilla-slab-highlight/scss/mixins.scss
+++ b/fonts/google/zilla-slab-highlight/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/google/zilla-slab/scss/mixins.scss
+++ b/fonts/google/zilla-slab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/icons/material-icons-outlined/scss/mixins.scss
+++ b/fonts/icons/material-icons-outlined/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/icons/material-icons-round/scss/mixins.scss
+++ b/fonts/icons/material-icons-round/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/icons/material-icons-sharp/scss/mixins.scss
+++ b/fonts/icons/material-icons-sharp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/icons/material-icons-two-tone/scss/mixins.scss
+++ b/fonts/icons/material-icons-two-tone/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/icons/material-icons/scss/mixins.scss
+++ b/fonts/icons/material-icons/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/icons/material-symbols-outlined/scss/mixins.scss
+++ b/fonts/icons/material-symbols-outlined/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/icons/material-symbols-rounded/scss/mixins.scss
+++ b/fonts/icons/material-symbols-rounded/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/icons/material-symbols-sharp/scss/mixins.scss
+++ b/fonts/icons/material-symbols-sharp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/aileron/scss/mixins.scss
+++ b/fonts/other/aileron/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/apfel-grotezk/scss/mixins.scss
+++ b/fonts/other/apfel-grotezk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/argentum-sans/scss/mixins.scss
+++ b/fonts/other/argentum-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/bagnard-sans/scss/mixins.scss
+++ b/fonts/other/bagnard-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/bagnard/scss/mixins.scss
+++ b/fonts/other/bagnard/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/blackout-midnight/scss/mixins.scss
+++ b/fonts/other/blackout-midnight/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/blackout-sunrise/scss/mixins.scss
+++ b/fonts/other/blackout-sunrise/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/blackout-two-am/scss/mixins.scss
+++ b/fonts/other/blackout-two-am/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/bluu-next/scss/mixins.scss
+++ b/fonts/other/bluu-next/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/bravura-text/scss/mixins.scss
+++ b/fonts/other/bravura-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/bravura/scss/mixins.scss
+++ b/fonts/other/bravura/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/chunk-five/scss/mixins.scss
+++ b/fonts/other/chunk-five/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/clear-sans/scss/mixins.scss
+++ b/fonts/other/clear-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/comic-mono/scss/mixins.scss
+++ b/fonts/other/comic-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/commit-mono/scss/mixins.scss
+++ b/fonts/other/commit-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/cooper-hewitt/scss/mixins.scss
+++ b/fonts/other/cooper-hewitt/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dejavu-math/scss/mixins.scss
+++ b/fonts/other/dejavu-math/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dejavu-mono/scss/mixins.scss
+++ b/fonts/other/dejavu-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dejavu-sans/scss/mixins.scss
+++ b/fonts/other/dejavu-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dejavu-serif/scss/mixins.scss
+++ b/fonts/other/dejavu-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dseg-weather/scss/mixins.scss
+++ b/fonts/other/dseg-weather/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dseg14-classic-mini/scss/mixins.scss
+++ b/fonts/other/dseg14-classic-mini/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dseg14-classic/scss/mixins.scss
+++ b/fonts/other/dseg14-classic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dseg14-modern-mini/scss/mixins.scss
+++ b/fonts/other/dseg14-modern-mini/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dseg14-modern/scss/mixins.scss
+++ b/fonts/other/dseg14-modern/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dseg7-classic-mini/scss/mixins.scss
+++ b/fonts/other/dseg7-classic-mini/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dseg7-classic/scss/mixins.scss
+++ b/fonts/other/dseg7-classic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dseg7-modern-mini/scss/mixins.scss
+++ b/fonts/other/dseg7-modern-mini/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dseg7-modern/scss/mixins.scss
+++ b/fonts/other/dseg7-modern/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dseg7-segg-chan-mini/scss/mixins.scss
+++ b/fonts/other/dseg7-segg-chan-mini/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/dseg7-segg-chan/scss/mixins.scss
+++ b/fonts/other/dseg7-segg-chan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/firago/scss/mixins.scss
+++ b/fonts/other/firago/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-kai-g/scss/mixins.scss
+++ b/fonts/other/fusion-kai-g/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-kai-j/scss/mixins.scss
+++ b/fonts/other/fusion-kai-j/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-kai-t/scss/mixins.scss
+++ b/fonts/other/fusion-kai-t/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-10px-monospaced-jp/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-10px-monospaced-jp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-10px-monospaced-kr/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-10px-monospaced-kr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-10px-monospaced-sc/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-10px-monospaced-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-10px-monospaced-tc/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-10px-monospaced-tc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-10px-proportional-jp/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-10px-proportional-jp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-10px-proportional-kr/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-10px-proportional-kr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-10px-proportional-sc/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-10px-proportional-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-10px-proportional-tc/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-10px-proportional-tc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-12px-monospaced-jp/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-12px-monospaced-jp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-12px-monospaced-kr/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-12px-monospaced-kr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-12px-monospaced-sc/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-12px-monospaced-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-12px-monospaced-tc/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-12px-monospaced-tc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-12px-proportional-jp/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-12px-proportional-jp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-12px-proportional-kr/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-12px-proportional-kr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-12px-proportional-sc/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-12px-proportional-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-12px-proportional-tc/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-12px-proportional-tc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-8px-monospaced-jp/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-8px-monospaced-jp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-8px-monospaced-kr/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-8px-monospaced-kr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-8px-monospaced-sc/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-8px-monospaced-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-8px-monospaced-tc/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-8px-monospaced-tc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-8px-proportional-jp/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-8px-proportional-jp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-8px-proportional-kr/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-8px-proportional-kr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-8px-proportional-sc/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-8px-proportional-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/fusion-pixel-8px-proportional-tc/scss/mixins.scss
+++ b/fonts/other/fusion-pixel-8px-proportional-tc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/geist-sans/scss/mixins.scss
+++ b/fonts/other/geist-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/genjyuu-gothic/scss/mixins.scss
+++ b/fonts/other/genjyuu-gothic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/hauora-sans/scss/mixins.scss
+++ b/fonts/other/hauora-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/ia-writer-duo/scss/mixins.scss
+++ b/fonts/other/ia-writer-duo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/ia-writer-mono/scss/mixins.scss
+++ b/fonts/other/ia-writer-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/ia-writer-quattro/scss/mixins.scss
+++ b/fonts/other/ia-writer-quattro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/iosevka-aile/scss/mixins.scss
+++ b/fonts/other/iosevka-aile/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/iosevka-curly-slab/scss/mixins.scss
+++ b/fonts/other/iosevka-curly-slab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/iosevka-curly/scss/mixins.scss
+++ b/fonts/other/iosevka-curly/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/iosevka-etoile/scss/mixins.scss
+++ b/fonts/other/iosevka-etoile/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/iosevka/scss/mixins.scss
+++ b/fonts/other/iosevka/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/junction/scss/mixins.scss
+++ b/fonts/other/junction/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/karmilla/scss/mixins.scss
+++ b/fonts/other/karmilla/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/league-mono/scss/mixins.scss
+++ b/fonts/other/league-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/lextrall/scss/mixins.scss
+++ b/fonts/other/lextrall/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/libre-caslon-condensed/scss/mixins.scss
+++ b/fonts/other/libre-caslon-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/lxgw-wenkai/scss/mixins.scss
+++ b/fonts/other/lxgw-wenkai/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/maple-mono/scss/mixins.scss
+++ b/fonts/other/maple-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/metropolis/scss/mixins.scss
+++ b/fonts/other/metropolis/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/monaspace-argon/scss/mixins.scss
+++ b/fonts/other/monaspace-argon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/monaspace-krypton/scss/mixins.scss
+++ b/fonts/other/monaspace-krypton/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/monaspace-neon/scss/mixins.scss
+++ b/fonts/other/monaspace-neon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/monaspace-radon/scss/mixins.scss
+++ b/fonts/other/monaspace-radon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/monaspace-xenon/scss/mixins.scss
+++ b/fonts/other/monaspace-xenon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/mononoki/scss/mixins.scss
+++ b/fonts/other/mononoki/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/national-park/scss/mixins.scss
+++ b/fonts/other/national-park/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/norwester/scss/mixins.scss
+++ b/fonts/other/norwester/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/noto-mono/scss/mixins.scss
+++ b/fonts/other/noto-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/open-sauce-one/scss/mixins.scss
+++ b/fonts/other/open-sauce-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/open-sauce-sans/scss/mixins.scss
+++ b/fonts/other/open-sauce-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/open-sauce-two/scss/mixins.scss
+++ b/fonts/other/open-sauce-two/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/opendyslexic/scss/mixins.scss
+++ b/fonts/other/opendyslexic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/ostrich-sans/scss/mixins.scss
+++ b/fonts/other/ostrich-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/peace-sans/scss/mixins.scss
+++ b/fonts/other/peace-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/pitagon-sans-mono/scss/mixins.scss
+++ b/fonts/other/pitagon-sans-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/pitagon-sans-text/scss/mixins.scss
+++ b/fonts/other/pitagon-sans-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/pitagon-sans/scss/mixins.scss
+++ b/fonts/other/pitagon-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/pitagon-serif/scss/mixins.scss
+++ b/fonts/other/pitagon-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/pretendard/scss/mixins.scss
+++ b/fonts/other/pretendard/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/redaction-10/scss/mixins.scss
+++ b/fonts/other/redaction-10/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/redaction-100/scss/mixins.scss
+++ b/fonts/other/redaction-100/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/redaction-20/scss/mixins.scss
+++ b/fonts/other/redaction-20/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/redaction-35/scss/mixins.scss
+++ b/fonts/other/redaction-35/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/redaction-50/scss/mixins.scss
+++ b/fonts/other/redaction-50/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/redaction-70/scss/mixins.scss
+++ b/fonts/other/redaction-70/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/redaction/scss/mixins.scss
+++ b/fonts/other/redaction/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/rubik-one/scss/mixins.scss
+++ b/fonts/other/rubik-one/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/sn-pro/scss/mixins.scss
+++ b/fonts/other/sn-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/syne-italic/scss/mixins.scss
+++ b/fonts/other/syne-italic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/uncut-sans/scss/mixins.scss
+++ b/fonts/other/uncut-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/unifont/scss/mixins.scss
+++ b/fonts/other/unifont/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/unifontex/scss/mixins.scss
+++ b/fonts/other/unifontex/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/win95fa/scss/mixins.scss
+++ b/fonts/other/win95fa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/yakuhanjp/scss/mixins.scss
+++ b/fonts/other/yakuhanjp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/yakuhanjps/scss/mixins.scss
+++ b/fonts/other/yakuhanjps/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/yakuhanmp/scss/mixins.scss
+++ b/fonts/other/yakuhanmp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/yakuhanmps/scss/mixins.scss
+++ b/fonts/other/yakuhanmps/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/yakuhanrp/scss/mixins.scss
+++ b/fonts/other/yakuhanrp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/other/yakuhanrps/scss/mixins.scss
+++ b/fonts/other/yakuhanrps/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable-icons/material-symbols-outlined/scss/mixins.scss
+++ b/fonts/variable-icons/material-symbols-outlined/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable-icons/material-symbols-rounded/scss/mixins.scss
+++ b/fonts/variable-icons/material-symbols-rounded/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable-icons/material-symbols-sharp/scss/mixins.scss
+++ b/fonts/variable-icons/material-symbols-sharp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/advent-pro/scss/mixins.scss
+++ b/fonts/variable/advent-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/afacad-flux/scss/mixins.scss
+++ b/fonts/variable/afacad-flux/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/afacad/scss/mixins.scss
+++ b/fonts/variable/afacad/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/agu-display/scss/mixins.scss
+++ b/fonts/variable/agu-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/akshar/scss/mixins.scss
+++ b/fonts/variable/akshar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/albert-sans/scss/mixins.scss
+++ b/fonts/variable/albert-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/alegreya/scss/mixins.scss
+++ b/fonts/variable/alegreya/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/aleo/scss/mixins.scss
+++ b/fonts/variable/aleo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/alexandria/scss/mixins.scss
+++ b/fonts/variable/alexandria/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/alkatra/scss/mixins.scss
+++ b/fonts/variable/alkatra/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/alumni-sans/scss/mixins.scss
+++ b/fonts/variable/alumni-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/anaheim/scss/mixins.scss
+++ b/fonts/variable/anaheim/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/andada-pro/scss/mixins.scss
+++ b/fonts/variable/andada-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/anek-bangla/scss/mixins.scss
+++ b/fonts/variable/anek-bangla/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/anek-devanagari/scss/mixins.scss
+++ b/fonts/variable/anek-devanagari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/anek-gujarati/scss/mixins.scss
+++ b/fonts/variable/anek-gujarati/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/anek-gurmukhi/scss/mixins.scss
+++ b/fonts/variable/anek-gurmukhi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/anek-kannada/scss/mixins.scss
+++ b/fonts/variable/anek-kannada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/anek-latin/scss/mixins.scss
+++ b/fonts/variable/anek-latin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/anek-malayalam/scss/mixins.scss
+++ b/fonts/variable/anek-malayalam/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/anek-odia/scss/mixins.scss
+++ b/fonts/variable/anek-odia/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/anek-tamil/scss/mixins.scss
+++ b/fonts/variable/anek-tamil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/anek-telugu/scss/mixins.scss
+++ b/fonts/variable/anek-telugu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/antonio/scss/mixins.scss
+++ b/fonts/variable/antonio/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/anuphan/scss/mixins.scss
+++ b/fonts/variable/anuphan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/anybody/scss/mixins.scss
+++ b/fonts/variable/anybody/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/ar-one-sans/scss/mixins.scss
+++ b/fonts/variable/ar-one-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/archivo-narrow/scss/mixins.scss
+++ b/fonts/variable/archivo-narrow/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/archivo/scss/mixins.scss
+++ b/fonts/variable/archivo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/arima/scss/mixins.scss
+++ b/fonts/variable/arima/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/arimo/scss/mixins.scss
+++ b/fonts/variable/arimo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/asap/scss/mixins.scss
+++ b/fonts/variable/asap/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/assistant/scss/mixins.scss
+++ b/fonts/variable/assistant/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/azeret-mono/scss/mixins.scss
+++ b/fonts/variable/azeret-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/ballet/scss/mixins.scss
+++ b/fonts/variable/ballet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/baloo-2/scss/mixins.scss
+++ b/fonts/variable/baloo-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/baloo-bhai-2/scss/mixins.scss
+++ b/fonts/variable/baloo-bhai-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/baloo-bhaijaan-2/scss/mixins.scss
+++ b/fonts/variable/baloo-bhaijaan-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/baloo-bhaina-2/scss/mixins.scss
+++ b/fonts/variable/baloo-bhaina-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/baloo-chettan-2/scss/mixins.scss
+++ b/fonts/variable/baloo-chettan-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/baloo-da-2/scss/mixins.scss
+++ b/fonts/variable/baloo-da-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/baloo-paaji-2/scss/mixins.scss
+++ b/fonts/variable/baloo-paaji-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/baloo-tamma-2/scss/mixins.scss
+++ b/fonts/variable/baloo-tamma-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/baloo-tammudu-2/scss/mixins.scss
+++ b/fonts/variable/baloo-tammudu-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/baloo-thambi-2/scss/mixins.scss
+++ b/fonts/variable/baloo-thambi-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/beiruti/scss/mixins.scss
+++ b/fonts/variable/beiruti/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/besley/scss/mixins.scss
+++ b/fonts/variable/besley/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/big-shoulders-display/scss/mixins.scss
+++ b/fonts/variable/big-shoulders-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/big-shoulders-inline-display/scss/mixins.scss
+++ b/fonts/variable/big-shoulders-inline-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/big-shoulders-inline-text/scss/mixins.scss
+++ b/fonts/variable/big-shoulders-inline-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/big-shoulders-stencil-display/scss/mixins.scss
+++ b/fonts/variable/big-shoulders-stencil-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/big-shoulders-stencil-text/scss/mixins.scss
+++ b/fonts/variable/big-shoulders-stencil-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/big-shoulders-text/scss/mixins.scss
+++ b/fonts/variable/big-shoulders-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/biorhyme/scss/mixins.scss
+++ b/fonts/variable/biorhyme/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/bitter/scss/mixins.scss
+++ b/fonts/variable/bitter/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/bodoni-moda-sc/scss/mixins.scss
+++ b/fonts/variable/bodoni-moda-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/bodoni-moda/scss/mixins.scss
+++ b/fonts/variable/bodoni-moda/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/bricolage-grotesque/scss/mixins.scss
+++ b/fonts/variable/bricolage-grotesque/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/briem-hand/scss/mixins.scss
+++ b/fonts/variable/briem-hand/scss/mixins.scss
@@ -95,7 +95,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/brygada-1918/scss/mixins.scss
+++ b/fonts/variable/brygada-1918/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/cabin/scss/mixins.scss
+++ b/fonts/variable/cabin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/cairo-play/scss/mixins.scss
+++ b/fonts/variable/cairo-play/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/cairo/scss/mixins.scss
+++ b/fonts/variable/cairo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/catamaran/scss/mixins.scss
+++ b/fonts/variable/catamaran/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/caveat/scss/mixins.scss
+++ b/fonts/variable/caveat/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/changa/scss/mixins.scss
+++ b/fonts/variable/changa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/chivo-mono/scss/mixins.scss
+++ b/fonts/variable/chivo-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/chivo/scss/mixins.scss
+++ b/fonts/variable/chivo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/cinzel/scss/mixins.scss
+++ b/fonts/variable/cinzel/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/climate-crisis/scss/mixins.scss
+++ b/fonts/variable/climate-crisis/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/comfortaa/scss/mixins.scss
+++ b/fonts/variable/comfortaa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/comme/scss/mixins.scss
+++ b/fonts/variable/comme/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/commissioner/scss/mixins.scss
+++ b/fonts/variable/commissioner/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/cormorant/scss/mixins.scss
+++ b/fonts/variable/cormorant/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/crimson-pro/scss/mixins.scss
+++ b/fonts/variable/crimson-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/cuprum/scss/mixins.scss
+++ b/fonts/variable/cuprum/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/dancing-script/scss/mixins.scss
+++ b/fonts/variable/dancing-script/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/danfo/scss/mixins.scss
+++ b/fonts/variable/danfo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/darker-grotesque/scss/mixins.scss
+++ b/fonts/variable/darker-grotesque/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/dm-sans/scss/mixins.scss
+++ b/fonts/variable/dm-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/domine/scss/mixins.scss
+++ b/fonts/variable/domine/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/dosis/scss/mixins.scss
+++ b/fonts/variable/dosis/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/doto/scss/mixins.scss
+++ b/fonts/variable/doto/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/dynapuff/scss/mixins.scss
+++ b/fonts/variable/dynapuff/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/eb-garamond/scss/mixins.scss
+++ b/fonts/variable/eb-garamond/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/eczar/scss/mixins.scss
+++ b/fonts/variable/eczar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/edu-au-vic-wa-nt-arrows/scss/mixins.scss
+++ b/fonts/variable/edu-au-vic-wa-nt-arrows/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/edu-au-vic-wa-nt-dots/scss/mixins.scss
+++ b/fonts/variable/edu-au-vic-wa-nt-dots/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/edu-au-vic-wa-nt-guides/scss/mixins.scss
+++ b/fonts/variable/edu-au-vic-wa-nt-guides/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/edu-au-vic-wa-nt-hand/scss/mixins.scss
+++ b/fonts/variable/edu-au-vic-wa-nt-hand/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/edu-au-vic-wa-nt-pre/scss/mixins.scss
+++ b/fonts/variable/edu-au-vic-wa-nt-pre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/edu-nsw-act-foundation/scss/mixins.scss
+++ b/fonts/variable/edu-nsw-act-foundation/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/edu-qld-beginner/scss/mixins.scss
+++ b/fonts/variable/edu-qld-beginner/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/edu-sa-beginner/scss/mixins.scss
+++ b/fonts/variable/edu-sa-beginner/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/edu-tas-beginner/scss/mixins.scss
+++ b/fonts/variable/edu-tas-beginner/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/edu-vic-wa-nt-beginner/scss/mixins.scss
+++ b/fonts/variable/edu-vic-wa-nt-beginner/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/el-messiri/scss/mixins.scss
+++ b/fonts/variable/el-messiri/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/encode-sans-sc/scss/mixins.scss
+++ b/fonts/variable/encode-sans-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/encode-sans/scss/mixins.scss
+++ b/fonts/variable/encode-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/epilogue/scss/mixins.scss
+++ b/fonts/variable/epilogue/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/exo-2/scss/mixins.scss
+++ b/fonts/variable/exo-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/exo/scss/mixins.scss
+++ b/fonts/variable/exo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/expletus-sans/scss/mixins.scss
+++ b/fonts/variable/expletus-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/familjen-grotesk/scss/mixins.scss
+++ b/fonts/variable/familjen-grotesk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/faustina/scss/mixins.scss
+++ b/fonts/variable/faustina/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/figtree/scss/mixins.scss
+++ b/fonts/variable/figtree/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/finlandica/scss/mixins.scss
+++ b/fonts/variable/finlandica/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/fira-code/scss/mixins.scss
+++ b/fonts/variable/fira-code/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/foldit/scss/mixins.scss
+++ b/fonts/variable/foldit/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/frank-ruhl-libre/scss/mixins.scss
+++ b/fonts/variable/frank-ruhl-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/fraunces/scss/mixins.scss
+++ b/fonts/variable/fraunces/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/fredoka/scss/mixins.scss
+++ b/fonts/variable/fredoka/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/funnel-display/scss/mixins.scss
+++ b/fonts/variable/funnel-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/funnel-sans/scss/mixins.scss
+++ b/fonts/variable/funnel-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/fustat/scss/mixins.scss
+++ b/fonts/variable/fustat/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/gabarito/scss/mixins.scss
+++ b/fonts/variable/gabarito/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/gantari/scss/mixins.scss
+++ b/fonts/variable/gantari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/geist-mono/scss/mixins.scss
+++ b/fonts/variable/geist-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/geist/scss/mixins.scss
+++ b/fonts/variable/geist/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/gelasio/scss/mixins.scss
+++ b/fonts/variable/gelasio/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/gemunu-libre/scss/mixins.scss
+++ b/fonts/variable/gemunu-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/genos/scss/mixins.scss
+++ b/fonts/variable/genos/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/geologica/scss/mixins.scss
+++ b/fonts/variable/geologica/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/georama/scss/mixins.scss
+++ b/fonts/variable/georama/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/glory/scss/mixins.scss
+++ b/fonts/variable/glory/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/gluten/scss/mixins.scss
+++ b/fonts/variable/gluten/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/golos-text/scss/mixins.scss
+++ b/fonts/variable/golos-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/grandstander/scss/mixins.scss
+++ b/fonts/variable/grandstander/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/grenze-gotisch/scss/mixins.scss
+++ b/fonts/variable/grenze-gotisch/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/hahmlet/scss/mixins.scss
+++ b/fonts/variable/hahmlet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/handjet/scss/mixins.scss
+++ b/fonts/variable/handjet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/hanken-grotesk/scss/mixins.scss
+++ b/fonts/variable/hanken-grotesk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/hedvig-letters-serif/scss/mixins.scss
+++ b/fonts/variable/hedvig-letters-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/heebo/scss/mixins.scss
+++ b/fonts/variable/heebo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/hepta-slab/scss/mixins.scss
+++ b/fonts/variable/hepta-slab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/honk/scss/mixins.scss
+++ b/fonts/variable/honk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/host-grotesk/scss/mixins.scss
+++ b/fonts/variable/host-grotesk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/hubot-sans/scss/mixins.scss
+++ b/fonts/variable/hubot-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/ibarra-real-nova/scss/mixins.scss
+++ b/fonts/variable/ibarra-real-nova/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/imbue/scss/mixins.scss
+++ b/fonts/variable/imbue/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/inconsolata/scss/mixins.scss
+++ b/fonts/variable/inconsolata/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/instrument-sans/scss/mixins.scss
+++ b/fonts/variable/instrument-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/inter-tight/scss/mixins.scss
+++ b/fonts/variable/inter-tight/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/inter/scss/mixins.scss
+++ b/fonts/variable/inter/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/jaro/scss/mixins.scss
+++ b/fonts/variable/jaro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/jetbrains-mono/scss/mixins.scss
+++ b/fonts/variable/jetbrains-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/josefin-sans/scss/mixins.scss
+++ b/fonts/variable/josefin-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/josefin-slab/scss/mixins.scss
+++ b/fonts/variable/josefin-slab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/jost/scss/mixins.scss
+++ b/fonts/variable/jost/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/jura/scss/mixins.scss
+++ b/fonts/variable/jura/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/kablammo/scss/mixins.scss
+++ b/fonts/variable/kablammo/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/kalnia-glaze/scss/mixins.scss
+++ b/fonts/variable/kalnia-glaze/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/kalnia/scss/mixins.scss
+++ b/fonts/variable/kalnia/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/kameron/scss/mixins.scss
+++ b/fonts/variable/kameron/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/kantumruy-pro/scss/mixins.scss
+++ b/fonts/variable/kantumruy-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/karla/scss/mixins.scss
+++ b/fonts/variable/karla/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/kode-mono/scss/mixins.scss
+++ b/fonts/variable/kode-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/kreon/scss/mixins.scss
+++ b/fonts/variable/kreon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/kufam/scss/mixins.scss
+++ b/fonts/variable/kufam/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/kumbh-sans/scss/mixins.scss
+++ b/fonts/variable/kumbh-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/labrada/scss/mixins.scss
+++ b/fonts/variable/labrada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/league-gothic/scss/mixins.scss
+++ b/fonts/variable/league-gothic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/league-spartan/scss/mixins.scss
+++ b/fonts/variable/league-spartan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/lemonada/scss/mixins.scss
+++ b/fonts/variable/lemonada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/lexend-deca/scss/mixins.scss
+++ b/fonts/variable/lexend-deca/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/lexend-exa/scss/mixins.scss
+++ b/fonts/variable/lexend-exa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/lexend-giga/scss/mixins.scss
+++ b/fonts/variable/lexend-giga/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/lexend-mega/scss/mixins.scss
+++ b/fonts/variable/lexend-mega/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/lexend-peta/scss/mixins.scss
+++ b/fonts/variable/lexend-peta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/lexend-tera/scss/mixins.scss
+++ b/fonts/variable/lexend-tera/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/lexend-zetta/scss/mixins.scss
+++ b/fonts/variable/lexend-zetta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/lexend/scss/mixins.scss
+++ b/fonts/variable/lexend/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/libre-bodoni/scss/mixins.scss
+++ b/fonts/variable/libre-bodoni/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/libre-franklin/scss/mixins.scss
+++ b/fonts/variable/libre-franklin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/linefont/scss/mixins.scss
+++ b/fonts/variable/linefont/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/literata/scss/mixins.scss
+++ b/fonts/variable/literata/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/lora/scss/mixins.scss
+++ b/fonts/variable/lora/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/m-plus-1-code/scss/mixins.scss
+++ b/fonts/variable/m-plus-1-code/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/m-plus-1/scss/mixins.scss
+++ b/fonts/variable/m-plus-1/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/m-plus-2/scss/mixins.scss
+++ b/fonts/variable/m-plus-2/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/m-plus-code-latin/scss/mixins.scss
+++ b/fonts/variable/m-plus-code-latin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/mada/scss/mixins.scss
+++ b/fonts/variable/mada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/manrope/scss/mixins.scss
+++ b/fonts/variable/manrope/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/manuale/scss/mixins.scss
+++ b/fonts/variable/manuale/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/marhey/scss/mixins.scss
+++ b/fonts/variable/marhey/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/markazi-text/scss/mixins.scss
+++ b/fonts/variable/markazi-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/martian-mono/scss/mixins.scss
+++ b/fonts/variable/martian-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/maven-pro/scss/mixins.scss
+++ b/fonts/variable/maven-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/merienda/scss/mixins.scss
+++ b/fonts/variable/merienda/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/merriweather-sans/scss/mixins.scss
+++ b/fonts/variable/merriweather-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/miriam-libre/scss/mixins.scss
+++ b/fonts/variable/miriam-libre/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/moderustic/scss/mixins.scss
+++ b/fonts/variable/moderustic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/mohave/scss/mixins.scss
+++ b/fonts/variable/mohave/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/mona-sans/scss/mixins.scss
+++ b/fonts/variable/mona-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/monda/scss/mixins.scss
+++ b/fonts/variable/monda/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/montagu-slab/scss/mixins.scss
+++ b/fonts/variable/montagu-slab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/montserrat-underline/scss/mixins.scss
+++ b/fonts/variable/montserrat-underline/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/montserrat/scss/mixins.scss
+++ b/fonts/variable/montserrat/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/mulish/scss/mixins.scss
+++ b/fonts/variable/mulish/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/murecho/scss/mixins.scss
+++ b/fonts/variable/murecho/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/museomoderno/scss/mixins.scss
+++ b/fonts/variable/museomoderno/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/nabla/scss/mixins.scss
+++ b/fonts/variable/nabla/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/newsreader/scss/mixins.scss
+++ b/fonts/variable/newsreader/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-emoji/scss/mixins.scss
+++ b/fonts/variable/noto-emoji/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-kufi-arabic/scss/mixins.scss
+++ b/fonts/variable/noto-kufi-arabic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-naskh-arabic/scss/mixins.scss
+++ b/fonts/variable/noto-naskh-arabic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-nastaliq-urdu/scss/mixins.scss
+++ b/fonts/variable/noto-nastaliq-urdu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-rashi-hebrew/scss/mixins.scss
+++ b/fonts/variable/noto-rashi-hebrew/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-adlam-unjoined/scss/mixins.scss
+++ b/fonts/variable/noto-sans-adlam-unjoined/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-adlam/scss/mixins.scss
+++ b/fonts/variable/noto-sans-adlam/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-arabic/scss/mixins.scss
+++ b/fonts/variable/noto-sans-arabic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-armenian/scss/mixins.scss
+++ b/fonts/variable/noto-sans-armenian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-balinese/scss/mixins.scss
+++ b/fonts/variable/noto-sans-balinese/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-bamum/scss/mixins.scss
+++ b/fonts/variable/noto-sans-bamum/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-bassa-vah/scss/mixins.scss
+++ b/fonts/variable/noto-sans-bassa-vah/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-bengali/scss/mixins.scss
+++ b/fonts/variable/noto-sans-bengali/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-canadian-aboriginal/scss/mixins.scss
+++ b/fonts/variable/noto-sans-canadian-aboriginal/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-cham/scss/mixins.scss
+++ b/fonts/variable/noto-sans-cham/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-cherokee/scss/mixins.scss
+++ b/fonts/variable/noto-sans-cherokee/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-devanagari/scss/mixins.scss
+++ b/fonts/variable/noto-sans-devanagari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-display/scss/mixins.scss
+++ b/fonts/variable/noto-sans-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-ethiopic/scss/mixins.scss
+++ b/fonts/variable/noto-sans-ethiopic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-georgian/scss/mixins.scss
+++ b/fonts/variable/noto-sans-georgian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-gujarati/scss/mixins.scss
+++ b/fonts/variable/noto-sans-gujarati/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-gunjala-gondi/scss/mixins.scss
+++ b/fonts/variable/noto-sans-gunjala-gondi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-gurmukhi/scss/mixins.scss
+++ b/fonts/variable/noto-sans-gurmukhi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-hanifi-rohingya/scss/mixins.scss
+++ b/fonts/variable/noto-sans-hanifi-rohingya/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-hebrew/scss/mixins.scss
+++ b/fonts/variable/noto-sans-hebrew/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-hk/scss/mixins.scss
+++ b/fonts/variable/noto-sans-hk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-javanese/scss/mixins.scss
+++ b/fonts/variable/noto-sans-javanese/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-jp/scss/mixins.scss
+++ b/fonts/variable/noto-sans-jp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-kannada/scss/mixins.scss
+++ b/fonts/variable/noto-sans-kannada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-kawi/scss/mixins.scss
+++ b/fonts/variable/noto-sans-kawi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-kayah-li/scss/mixins.scss
+++ b/fonts/variable/noto-sans-kayah-li/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-khmer/scss/mixins.scss
+++ b/fonts/variable/noto-sans-khmer/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-kr/scss/mixins.scss
+++ b/fonts/variable/noto-sans-kr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-lao-looped/scss/mixins.scss
+++ b/fonts/variable/noto-sans-lao-looped/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-lao/scss/mixins.scss
+++ b/fonts/variable/noto-sans-lao/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-lisu/scss/mixins.scss
+++ b/fonts/variable/noto-sans-lisu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-malayalam/scss/mixins.scss
+++ b/fonts/variable/noto-sans-malayalam/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-medefaidrin/scss/mixins.scss
+++ b/fonts/variable/noto-sans-medefaidrin/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-meetei-mayek/scss/mixins.scss
+++ b/fonts/variable/noto-sans-meetei-mayek/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-mono/scss/mixins.scss
+++ b/fonts/variable/noto-sans-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-nag-mundari/scss/mixins.scss
+++ b/fonts/variable/noto-sans-nag-mundari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-new-tai-lue/scss/mixins.scss
+++ b/fonts/variable/noto-sans-new-tai-lue/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-nko-unjoined/scss/mixins.scss
+++ b/fonts/variable/noto-sans-nko-unjoined/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-ol-chiki/scss/mixins.scss
+++ b/fonts/variable/noto-sans-ol-chiki/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-oriya/scss/mixins.scss
+++ b/fonts/variable/noto-sans-oriya/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-sc/scss/mixins.scss
+++ b/fonts/variable/noto-sans-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-sinhala/scss/mixins.scss
+++ b/fonts/variable/noto-sans-sinhala/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-sora-sompeng/scss/mixins.scss
+++ b/fonts/variable/noto-sans-sora-sompeng/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-sundanese/scss/mixins.scss
+++ b/fonts/variable/noto-sans-sundanese/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-symbols/scss/mixins.scss
+++ b/fonts/variable/noto-sans-symbols/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-syriac-eastern/scss/mixins.scss
+++ b/fonts/variable/noto-sans-syriac-eastern/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-syriac/scss/mixins.scss
+++ b/fonts/variable/noto-sans-syriac/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-tai-tham/scss/mixins.scss
+++ b/fonts/variable/noto-sans-tai-tham/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-tamil/scss/mixins.scss
+++ b/fonts/variable/noto-sans-tamil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-tangsa/scss/mixins.scss
+++ b/fonts/variable/noto-sans-tangsa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-tc/scss/mixins.scss
+++ b/fonts/variable/noto-sans-tc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-telugu/scss/mixins.scss
+++ b/fonts/variable/noto-sans-telugu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-thaana/scss/mixins.scss
+++ b/fonts/variable/noto-sans-thaana/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-thai/scss/mixins.scss
+++ b/fonts/variable/noto-sans-thai/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans-vithkuqi/scss/mixins.scss
+++ b/fonts/variable/noto-sans-vithkuqi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-sans/scss/mixins.scss
+++ b/fonts/variable/noto-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-armenian/scss/mixins.scss
+++ b/fonts/variable/noto-serif-armenian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-bengali/scss/mixins.scss
+++ b/fonts/variable/noto-serif-bengali/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-devanagari/scss/mixins.scss
+++ b/fonts/variable/noto-serif-devanagari/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-display/scss/mixins.scss
+++ b/fonts/variable/noto-serif-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-ethiopic/scss/mixins.scss
+++ b/fonts/variable/noto-serif-ethiopic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-georgian/scss/mixins.scss
+++ b/fonts/variable/noto-serif-georgian/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-gujarati/scss/mixins.scss
+++ b/fonts/variable/noto-serif-gujarati/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-gurmukhi/scss/mixins.scss
+++ b/fonts/variable/noto-serif-gurmukhi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-hebrew/scss/mixins.scss
+++ b/fonts/variable/noto-serif-hebrew/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-hk/scss/mixins.scss
+++ b/fonts/variable/noto-serif-hk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-jp/scss/mixins.scss
+++ b/fonts/variable/noto-serif-jp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-kannada/scss/mixins.scss
+++ b/fonts/variable/noto-serif-kannada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-khmer/scss/mixins.scss
+++ b/fonts/variable/noto-serif-khmer/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-khojki/scss/mixins.scss
+++ b/fonts/variable/noto-serif-khojki/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-kr/scss/mixins.scss
+++ b/fonts/variable/noto-serif-kr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-lao/scss/mixins.scss
+++ b/fonts/variable/noto-serif-lao/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-malayalam/scss/mixins.scss
+++ b/fonts/variable/noto-serif-malayalam/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-np-hmong/scss/mixins.scss
+++ b/fonts/variable/noto-serif-np-hmong/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-oriya/scss/mixins.scss
+++ b/fonts/variable/noto-serif-oriya/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-sc/scss/mixins.scss
+++ b/fonts/variable/noto-serif-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-sinhala/scss/mixins.scss
+++ b/fonts/variable/noto-serif-sinhala/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-tamil/scss/mixins.scss
+++ b/fonts/variable/noto-serif-tamil/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-tc/scss/mixins.scss
+++ b/fonts/variable/noto-serif-tc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-telugu/scss/mixins.scss
+++ b/fonts/variable/noto-serif-telugu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-thai/scss/mixins.scss
+++ b/fonts/variable/noto-serif-thai/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-tibetan/scss/mixins.scss
+++ b/fonts/variable/noto-serif-tibetan/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-toto/scss/mixins.scss
+++ b/fonts/variable/noto-serif-toto/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-vithkuqi/scss/mixins.scss
+++ b/fonts/variable/noto-serif-vithkuqi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif-yezidi/scss/mixins.scss
+++ b/fonts/variable/noto-serif-yezidi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-serif/scss/mixins.scss
+++ b/fonts/variable/noto-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/noto-traditional-nushu/scss/mixins.scss
+++ b/fonts/variable/noto-traditional-nushu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/nunito-sans/scss/mixins.scss
+++ b/fonts/variable/nunito-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/nunito/scss/mixins.scss
+++ b/fonts/variable/nunito/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/ojuju/scss/mixins.scss
+++ b/fonts/variable/ojuju/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/onest/scss/mixins.scss
+++ b/fonts/variable/onest/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/open-sans/scss/mixins.scss
+++ b/fonts/variable/open-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/orbitron/scss/mixins.scss
+++ b/fonts/variable/orbitron/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/oswald/scss/mixins.scss
+++ b/fonts/variable/oswald/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/outfit/scss/mixins.scss
+++ b/fonts/variable/outfit/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/overpass-mono/scss/mixins.scss
+++ b/fonts/variable/overpass-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/overpass/scss/mixins.scss
+++ b/fonts/variable/overpass/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/oxanium/scss/mixins.scss
+++ b/fonts/variable/oxanium/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/parkinsans/scss/mixins.scss
+++ b/fonts/variable/parkinsans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/pathway-extreme/scss/mixins.scss
+++ b/fonts/variable/pathway-extreme/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/petrona/scss/mixins.scss
+++ b/fonts/variable/petrona/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/phudu/scss/mixins.scss
+++ b/fonts/variable/phudu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/piazzolla/scss/mixins.scss
+++ b/fonts/variable/piazzolla/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/pixelify-sans/scss/mixins.scss
+++ b/fonts/variable/pixelify-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/platypi/scss/mixins.scss
+++ b/fonts/variable/platypi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playfair-display/scss/mixins.scss
+++ b/fonts/variable/playfair-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playfair/scss/mixins.scss
+++ b/fonts/variable/playfair/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playpen-sans/scss/mixins.scss
+++ b/fonts/variable/playpen-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-ar/scss/mixins.scss
+++ b/fonts/variable/playwrite-ar/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-at/scss/mixins.scss
+++ b/fonts/variable/playwrite-at/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-au-nsw/scss/mixins.scss
+++ b/fonts/variable/playwrite-au-nsw/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-au-qld/scss/mixins.scss
+++ b/fonts/variable/playwrite-au-qld/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-au-sa/scss/mixins.scss
+++ b/fonts/variable/playwrite-au-sa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-au-tas/scss/mixins.scss
+++ b/fonts/variable/playwrite-au-tas/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-au-vic/scss/mixins.scss
+++ b/fonts/variable/playwrite-au-vic/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-be-vlg/scss/mixins.scss
+++ b/fonts/variable/playwrite-be-vlg/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-be-wal/scss/mixins.scss
+++ b/fonts/variable/playwrite-be-wal/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-br/scss/mixins.scss
+++ b/fonts/variable/playwrite-br/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-ca/scss/mixins.scss
+++ b/fonts/variable/playwrite-ca/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-cl/scss/mixins.scss
+++ b/fonts/variable/playwrite-cl/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-co/scss/mixins.scss
+++ b/fonts/variable/playwrite-co/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-cu/scss/mixins.scss
+++ b/fonts/variable/playwrite-cu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-cz/scss/mixins.scss
+++ b/fonts/variable/playwrite-cz/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-de-grund/scss/mixins.scss
+++ b/fonts/variable/playwrite-de-grund/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-de-la/scss/mixins.scss
+++ b/fonts/variable/playwrite-de-la/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-de-sas/scss/mixins.scss
+++ b/fonts/variable/playwrite-de-sas/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-de-va/scss/mixins.scss
+++ b/fonts/variable/playwrite-de-va/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-dk-loopet/scss/mixins.scss
+++ b/fonts/variable/playwrite-dk-loopet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-dk-uloopet/scss/mixins.scss
+++ b/fonts/variable/playwrite-dk-uloopet/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-es-deco/scss/mixins.scss
+++ b/fonts/variable/playwrite-es-deco/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-es/scss/mixins.scss
+++ b/fonts/variable/playwrite-es/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-fr-moderne/scss/mixins.scss
+++ b/fonts/variable/playwrite-fr-moderne/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-fr-trad/scss/mixins.scss
+++ b/fonts/variable/playwrite-fr-trad/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-gb-j/scss/mixins.scss
+++ b/fonts/variable/playwrite-gb-j/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-gb-s/scss/mixins.scss
+++ b/fonts/variable/playwrite-gb-s/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-hr-lijeva/scss/mixins.scss
+++ b/fonts/variable/playwrite-hr-lijeva/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-hr/scss/mixins.scss
+++ b/fonts/variable/playwrite-hr/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-hu/scss/mixins.scss
+++ b/fonts/variable/playwrite-hu/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-id/scss/mixins.scss
+++ b/fonts/variable/playwrite-id/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-ie/scss/mixins.scss
+++ b/fonts/variable/playwrite-ie/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-in/scss/mixins.scss
+++ b/fonts/variable/playwrite-in/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-is/scss/mixins.scss
+++ b/fonts/variable/playwrite-is/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-it-moderna/scss/mixins.scss
+++ b/fonts/variable/playwrite-it-moderna/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-it-trad/scss/mixins.scss
+++ b/fonts/variable/playwrite-it-trad/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-mx/scss/mixins.scss
+++ b/fonts/variable/playwrite-mx/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-ng-modern/scss/mixins.scss
+++ b/fonts/variable/playwrite-ng-modern/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-nl/scss/mixins.scss
+++ b/fonts/variable/playwrite-nl/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-no/scss/mixins.scss
+++ b/fonts/variable/playwrite-no/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-nz/scss/mixins.scss
+++ b/fonts/variable/playwrite-nz/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-pe/scss/mixins.scss
+++ b/fonts/variable/playwrite-pe/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-pl/scss/mixins.scss
+++ b/fonts/variable/playwrite-pl/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-pt/scss/mixins.scss
+++ b/fonts/variable/playwrite-pt/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-ro/scss/mixins.scss
+++ b/fonts/variable/playwrite-ro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-sk/scss/mixins.scss
+++ b/fonts/variable/playwrite-sk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-tz/scss/mixins.scss
+++ b/fonts/variable/playwrite-tz/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-us-modern/scss/mixins.scss
+++ b/fonts/variable/playwrite-us-modern/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-us-trad/scss/mixins.scss
+++ b/fonts/variable/playwrite-us-trad/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-vn/scss/mixins.scss
+++ b/fonts/variable/playwrite-vn/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/playwrite-za/scss/mixins.scss
+++ b/fonts/variable/playwrite-za/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/plus-jakarta-sans/scss/mixins.scss
+++ b/fonts/variable/plus-jakarta-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/podkova/scss/mixins.scss
+++ b/fonts/variable/podkova/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/poltawski-nowy/scss/mixins.scss
+++ b/fonts/variable/poltawski-nowy/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/pontano-sans/scss/mixins.scss
+++ b/fonts/variable/pontano-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/public-sans/scss/mixins.scss
+++ b/fonts/variable/public-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/quicksand/scss/mixins.scss
+++ b/fonts/variable/quicksand/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/radio-canada-big/scss/mixins.scss
+++ b/fonts/variable/radio-canada-big/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/radio-canada/scss/mixins.scss
+++ b/fonts/variable/radio-canada/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/raleway/scss/mixins.scss
+++ b/fonts/variable/raleway/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/rasa/scss/mixins.scss
+++ b/fonts/variable/rasa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/readex-pro/scss/mixins.scss
+++ b/fonts/variable/readex-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/recursive/scss/mixins.scss
+++ b/fonts/variable/recursive/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/red-hat-display/scss/mixins.scss
+++ b/fonts/variable/red-hat-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/red-hat-mono/scss/mixins.scss
+++ b/fonts/variable/red-hat-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/red-hat-text/scss/mixins.scss
+++ b/fonts/variable/red-hat-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/red-rose/scss/mixins.scss
+++ b/fonts/variable/red-rose/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/reddit-mono/scss/mixins.scss
+++ b/fonts/variable/reddit-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/reddit-sans-condensed/scss/mixins.scss
+++ b/fonts/variable/reddit-sans-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/reddit-sans/scss/mixins.scss
+++ b/fonts/variable/reddit-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/reem-kufi-fun/scss/mixins.scss
+++ b/fonts/variable/reem-kufi-fun/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/reem-kufi/scss/mixins.scss
+++ b/fonts/variable/reem-kufi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/rem/scss/mixins.scss
+++ b/fonts/variable/rem/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/rethink-sans/scss/mixins.scss
+++ b/fonts/variable/rethink-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/roboto-condensed/scss/mixins.scss
+++ b/fonts/variable/roboto-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/roboto-flex/scss/mixins.scss
+++ b/fonts/variable/roboto-flex/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/roboto-mono/scss/mixins.scss
+++ b/fonts/variable/roboto-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/roboto-serif/scss/mixins.scss
+++ b/fonts/variable/roboto-serif/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/roboto-slab/scss/mixins.scss
+++ b/fonts/variable/roboto-slab/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/rokkitt/scss/mixins.scss
+++ b/fonts/variable/rokkitt/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/rosario/scss/mixins.scss
+++ b/fonts/variable/rosario/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/rubik/scss/mixins.scss
+++ b/fonts/variable/rubik/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/ruda/scss/mixins.scss
+++ b/fonts/variable/ruda/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/saira/scss/mixins.scss
+++ b/fonts/variable/saira/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/sansita-swashed/scss/mixins.scss
+++ b/fonts/variable/sansita-swashed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/schibsted-grotesk/scss/mixins.scss
+++ b/fonts/variable/schibsted-grotesk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/sen/scss/mixins.scss
+++ b/fonts/variable/sen/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/shantell-sans/scss/mixins.scss
+++ b/fonts/variable/shantell-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/signika-negative/scss/mixins.scss
+++ b/fonts/variable/signika-negative/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/signika/scss/mixins.scss
+++ b/fonts/variable/signika/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/sixtyfour-convergence/scss/mixins.scss
+++ b/fonts/variable/sixtyfour-convergence/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/sixtyfour/scss/mixins.scss
+++ b/fonts/variable/sixtyfour/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/smooch-sans/scss/mixins.scss
+++ b/fonts/variable/smooch-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/sofia-sans-condensed/scss/mixins.scss
+++ b/fonts/variable/sofia-sans-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/sofia-sans-extra-condensed/scss/mixins.scss
+++ b/fonts/variable/sofia-sans-extra-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/sofia-sans-semi-condensed/scss/mixins.scss
+++ b/fonts/variable/sofia-sans-semi-condensed/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/sofia-sans/scss/mixins.scss
+++ b/fonts/variable/sofia-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/sometype-mono/scss/mixins.scss
+++ b/fonts/variable/sometype-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/sono/scss/mixins.scss
+++ b/fonts/variable/sono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/sora/scss/mixins.scss
+++ b/fonts/variable/sora/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/sour-gummy/scss/mixins.scss
+++ b/fonts/variable/sour-gummy/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/source-code-pro/scss/mixins.scss
+++ b/fonts/variable/source-code-pro/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/source-sans-3/scss/mixins.scss
+++ b/fonts/variable/source-sans-3/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/source-serif-4/scss/mixins.scss
+++ b/fonts/variable/source-serif-4/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/space-grotesk/scss/mixins.scss
+++ b/fonts/variable/space-grotesk/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/spline-sans-mono/scss/mixins.scss
+++ b/fonts/variable/spline-sans-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/spline-sans/scss/mixins.scss
+++ b/fonts/variable/spline-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/stick-no-bills/scss/mixins.scss
+++ b/fonts/variable/stick-no-bills/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/stix-two-text/scss/mixins.scss
+++ b/fonts/variable/stix-two-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/suse/scss/mixins.scss
+++ b/fonts/variable/suse/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/syne/scss/mixins.scss
+++ b/fonts/variable/syne/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/teachers/scss/mixins.scss
+++ b/fonts/variable/teachers/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/teko/scss/mixins.scss
+++ b/fonts/variable/teko/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/tektur/scss/mixins.scss
+++ b/fonts/variable/tektur/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/texturina/scss/mixins.scss
+++ b/fonts/variable/texturina/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/tilt-neon/scss/mixins.scss
+++ b/fonts/variable/tilt-neon/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/tilt-prism/scss/mixins.scss
+++ b/fonts/variable/tilt-prism/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/tilt-warp/scss/mixins.scss
+++ b/fonts/variable/tilt-warp/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/tourney/scss/mixins.scss
+++ b/fonts/variable/tourney/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/trispace/scss/mixins.scss
+++ b/fonts/variable/trispace/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/truculenta/scss/mixins.scss
+++ b/fonts/variable/truculenta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/ubuntu-sans-mono/scss/mixins.scss
+++ b/fonts/variable/ubuntu-sans-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/ubuntu-sans/scss/mixins.scss
+++ b/fonts/variable/ubuntu-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/unbounded/scss/mixins.scss
+++ b/fonts/variable/unbounded/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/urbanist/scss/mixins.scss
+++ b/fonts/variable/urbanist/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/varta/scss/mixins.scss
+++ b/fonts/variable/varta/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/vazirmatn/scss/mixins.scss
+++ b/fonts/variable/vazirmatn/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/victor-mono/scss/mixins.scss
+++ b/fonts/variable/victor-mono/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/vollkorn/scss/mixins.scss
+++ b/fonts/variable/vollkorn/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/wavefont/scss/mixins.scss
+++ b/fonts/variable/wavefont/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/wittgenstein/scss/mixins.scss
+++ b/fonts/variable/wittgenstein/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/wix-madefor-display/scss/mixins.scss
+++ b/fonts/variable/wix-madefor-display/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/wix-madefor-text/scss/mixins.scss
+++ b/fonts/variable/wix-madefor-text/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/work-sans/scss/mixins.scss
+++ b/fonts/variable/work-sans/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/workbench/scss/mixins.scss
+++ b/fonts/variable/workbench/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/yaldevi/scss/mixins.scss
+++ b/fonts/variable/yaldevi/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/yanone-kaffeesatz/scss/mixins.scss
+++ b/fonts/variable/yanone-kaffeesatz/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/yrsa/scss/mixins.scss
+++ b/fonts/variable/yrsa/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/ysabeau-infant/scss/mixins.scss
+++ b/fonts/variable/ysabeau-infant/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/ysabeau-office/scss/mixins.scss
+++ b/fonts/variable/ysabeau-office/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/ysabeau-sc/scss/mixins.scss
+++ b/fonts/variable/ysabeau-sc/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),

--- a/fonts/variable/ysabeau/scss/mixins.scss
+++ b/fonts/variable/ysabeau/scss/mixins.scss
@@ -96,7 +96,7 @@ $displayVar: null !default;
 
               $src: ();
               @each $format in $formats {
-                $src: append(
+                $src: list.append(
                   $src,
                   url('#{$directory}/#{$variant}.#{$format}')
                     format('#{$format}#{if($axis, '-variations', '')}'),


### PR DESCRIPTION
This PR is related to this issue: https://github.com/fontsource/fontsource/issues/1000#issuecomment-2596210851

I thought it would be wise to add the `list.append` from sass, it seems it's the only one missing the scope name.

Sorry if this is the wrong place to fix it, it's my first time contributing. :)