### PR TITLE
refactor(sources): simplify registry metadata

### DIFF
--- a/sources/adwaita-mono/metadata.json
+++ b/sources/adwaita-mono/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"monospace"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "The GNOME Project",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://gitlab.gnome.org/GNOME/adwaita-fonts",
 		"revision": "bd828c71418f7ae3af76687d6ca2a809111770f2"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/AdwaitaMono-Bold.ttf",

--- a/sources/adwaita-sans/metadata.json
+++ b/sources/adwaita-sans/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "The GNOME Project",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://gitlab.gnome.org/GNOME/adwaita-fonts",
 		"revision": "bd828c71418f7ae3af76687d6ca2a809111770f2"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/AdwaitaSans-Italic.ttf",

--- a/sources/argentum-sans/metadata.json
+++ b/sources/argentum-sans/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "The Argentum Sans Project Authors",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/cssobral2013/Argentum-Sans",
 		"revision": "396d0c5b9a1c520215e2c4d2fd7e8b9165c4e4d6"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/ArgentumSans-Italic-VF.ttf",

--- a/sources/bagnard-sans/metadata.json
+++ b/sources/bagnard-sans/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Sébastien Sanfilippo",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/dconstruct/Bagnard",
 		"revision": "92146404d08a0a12259b5abb9a658b94f4480058"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/BagnardSans.otf",

--- a/sources/bagnard/metadata.json
+++ b/sources/bagnard/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Sébastien Sanfilippo",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/dconstruct/Bagnard",
 		"revision": "92146404d08a0a12259b5abb9a658b94f4480058"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Bagnard.otf",

--- a/sources/blackout-midnight/metadata.json
+++ b/sources/blackout-midnight/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"display"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Tyler Finck",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/theleagueof/blackout",
 		"revision": "4864cfc1749590e9f78549c6e57116fe98480c0f"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Blackout Midnight.ttf",

--- a/sources/blackout-sunrise/metadata.json
+++ b/sources/blackout-sunrise/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"display"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Tyler Finck",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/theleagueof/blackout",
 		"revision": "4864cfc1749590e9f78549c6e57116fe98480c0f"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Blackout Sunrise.ttf",

--- a/sources/blackout-two-am/metadata.json
+++ b/sources/blackout-two-am/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"display"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Tyler Finck",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/theleagueof/blackout",
 		"revision": "4864cfc1749590e9f78549c6e57116fe98480c0f"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Blackout 2 AM.ttf",

--- a/sources/bluu-next/metadata.json
+++ b/sources/bluu-next/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Jean-Baptiste Morizot",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/jbmorizot/BluuNext",
 		"revision": "82101a9970b26a7421cfe27bce32fd6533f02109"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/BluuNext-Bold.otf",

--- a/sources/chunk-five/metadata.json
+++ b/sources/chunk-five/metadata.json
@@ -5,8 +5,6 @@
 		"display",
 		"serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Meredith Mandel",
 	"license": {
@@ -18,7 +16,6 @@
 		"repository": "https://github.com/theleagueof/chunk",
 		"revision": "12a243f3fb7c7a68844901023f7d95d6eaf14104"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/ChunkFive-Regular.ttf",

--- a/sources/clear-sans/metadata.json
+++ b/sources/clear-sans/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Daniel Rhatigan",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/intel/clear-sans",
 		"revision": "1993725b24a36af21e7ebaa8977103983b608572"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/ClearSans-Bold.ttf",

--- a/sources/comic-mono/metadata.json
+++ b/sources/comic-mono/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"monospace"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Shannon Miwa and dtinth",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/dtinth/comic-mono-font",
 		"revision": "13eb162648d01d61ece424088dbf750ec80a1a62"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/ComicMono-Bold.ttf",

--- a/sources/commit-mono/metadata.json
+++ b/sources/commit-mono/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"monospace"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Eigil Nikolajsen",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/eigilnikolajsen/commit-mono",
 		"revision": "d407cd2bf8e01ca1db70544052fbbb9606406c3b"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/CommitMonoV143-VF.ttf",

--- a/sources/cooper-hewitt/metadata.json
+++ b/sources/cooper-hewitt/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Chester Jenkins",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/cooperhewitt/cooperhewitt-typeface",
 		"revision": "4480445381f1fe6633d7a59504b7bddd4bc0e82e"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/CooperHewitt-Bold.otf",

--- a/sources/hauora-sans/metadata.json
+++ b/sources/hauora-sans/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "WCYS & Co.",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/WCYS-Co/Hauora-Sans",
 		"revision": "75131397db767f52236dde990405aad2deaf9cb6"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Hauora[wght].ttf",

--- a/sources/ia-writer-duo/metadata.json
+++ b/sources/ia-writer-duo/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"monospace"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Information Architects Inc.",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/iaolo/iA-Fonts",
 		"revision": "f32c04c3058a75d7ce28919ce70fe8800817491b"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/iAWriterDuoV-Italic.ttf",

--- a/sources/ia-writer-mono/metadata.json
+++ b/sources/ia-writer-mono/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"monospace"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Information Architects Inc.",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/iaolo/iA-Fonts",
 		"revision": "f32c04c3058a75d7ce28919ce70fe8800817491b"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/iAWriterMonoV-Italic.ttf",

--- a/sources/ia-writer-quattro/metadata.json
+++ b/sources/ia-writer-quattro/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Information Architects Inc.",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/iaolo/iA-Fonts",
 		"revision": "f32c04c3058a75d7ce28919ce70fe8800817491b"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/iAWriterQuattroV-Italic.ttf",

--- a/sources/junction/metadata.json
+++ b/sources/junction/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Caroline Hadilaksono and Tyler Finck",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/theleagueof/junction",
 		"revision": "fb73260e86dd301b383cf6cc9ca8e726ef806535"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Junction-bold.otf",

--- a/sources/karmilla/metadata.json
+++ b/sources/karmilla/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "The Karmilla Project Authors",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/ms-studio/karmilla",
 		"revision": "2071ea77d2bca635b61ed6e4db4aeff56f9f90ac"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Karmilla-Bold-015.ttf",

--- a/sources/league-mono/metadata.json
+++ b/sources/league-mono/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"monospace"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Tyler Finck",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/theleagueof/league-mono",
 		"revision": "7a3b0f7393f17f54f6c65b3ca983fe52b2af101f"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/LeagueMonoVariable.ttf",

--- a/sources/lextrall/metadata.json
+++ b/sources/lextrall/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Amuzil",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/amuzil/lextrall",
 		"revision": "69bffcbc19ac72542b82dd74462075dcfb912813"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Lextrall[HEXP,wght].ttf",

--- a/sources/libre-caslon-condensed/metadata.json
+++ b/sources/libre-caslon-condensed/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Ertekin Erdin",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/ertekinno/libre-caslon-condensed",
 		"revision": "e3b55edea5a9d67a347caaa1d9c04618ffe7b4d7"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/LibreCaslonCondensed-Italic[wght].ttf",

--- a/sources/maple-mono/metadata.json
+++ b/sources/maple-mono/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"monospace"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Subframe7536",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/subframe7536/maple-font",
 		"revision": "4d847729cbfc5b5d8cbae5795fd2348c70112648"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/MapleMono-Italic[wght].ttf",

--- a/sources/metropolis/metadata.json
+++ b/sources/metropolis/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Chris Simpson",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/dw5/Metropolis",
 		"revision": "79b4b2e1164f5184edd5e3ba8b4acb590a9e7821"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Metropolis-Black.ttf",

--- a/sources/monaspace-argon/metadata.json
+++ b/sources/monaspace-argon/metadata.json
@@ -5,8 +5,6 @@
 		"monospace",
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "GitHub Next",
 	"license": {
@@ -18,7 +16,6 @@
 		"repository": "https://github.com/githubnext/monaspace",
 		"revision": "f31794b6e9e65698a062262e2f826f679dcb7070"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Monaspace Argon Var.ttf",

--- a/sources/monaspace-krypton/metadata.json
+++ b/sources/monaspace-krypton/metadata.json
@@ -5,8 +5,6 @@
 		"monospace",
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "GitHub Next",
 	"license": {
@@ -18,7 +16,6 @@
 		"repository": "https://github.com/githubnext/monaspace",
 		"revision": "f31794b6e9e65698a062262e2f826f679dcb7070"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Monaspace Krypton Var.ttf",

--- a/sources/monaspace-neon/metadata.json
+++ b/sources/monaspace-neon/metadata.json
@@ -5,8 +5,6 @@
 		"monospace",
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "GitHub Next",
 	"license": {
@@ -18,7 +16,6 @@
 		"repository": "https://github.com/githubnext/monaspace",
 		"revision": "f31794b6e9e65698a062262e2f826f679dcb7070"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Monaspace Neon Var.ttf",

--- a/sources/monaspace-radon/metadata.json
+++ b/sources/monaspace-radon/metadata.json
@@ -5,8 +5,6 @@
 		"monospace",
 		"handwriting"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "GitHub Next",
 	"license": {
@@ -18,7 +16,6 @@
 		"repository": "https://github.com/githubnext/monaspace",
 		"revision": "f31794b6e9e65698a062262e2f826f679dcb7070"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Monaspace Radon Var.ttf",

--- a/sources/monaspace-xenon/metadata.json
+++ b/sources/monaspace-xenon/metadata.json
@@ -5,8 +5,6 @@
 		"monospace",
 		"slab-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "GitHub Next",
 	"license": {
@@ -18,7 +16,6 @@
 		"repository": "https://github.com/githubnext/monaspace",
 		"revision": "f31794b6e9e65698a062262e2f826f679dcb7070"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Monaspace Xenon Var.ttf",

--- a/sources/mononoki/metadata.json
+++ b/sources/mononoki/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"monospace"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Matthias Tellen",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/madmalik/mononoki",
 		"revision": "089d2a4c07fe805432bbe54dc097dc715f90071a"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/mononoki-Bold.ttf",

--- a/sources/open-runde/metadata.json
+++ b/sources/open-runde/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Laurids Kern",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/lauridskern/open-runde",
 		"revision": "3e7ed7f3cdfa5523766db7e430066472615fc935"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/OpenRunde-Bold.otf",

--- a/sources/open-sauce-one/metadata.json
+++ b/sources/open-sauce-one/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Alfredo Marco Pradil",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/marcologous/Open-Sauce-Fonts",
 		"revision": "1747e4467caf9ecce17690ae6880d86a03e17c41"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/OpenSauceOne-Black.ttf",

--- a/sources/open-sauce-sans/metadata.json
+++ b/sources/open-sauce-sans/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Alfredo Marco Pradil",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/marcologous/Open-Sauce-Fonts",
 		"revision": "1747e4467caf9ecce17690ae6880d86a03e17c41"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/OpenSauceSans-Black.ttf",

--- a/sources/open-sauce-two/metadata.json
+++ b/sources/open-sauce-two/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Alfredo Marco Pradil",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/marcologous/Open-Sauce-Fonts",
 		"revision": "1747e4467caf9ecce17690ae6880d86a03e17c41"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/OpenSauceTwo-Black.ttf",

--- a/sources/opendyslexic/metadata.json
+++ b/sources/opendyslexic/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Abbie Gonzalez",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://forge.hackers.town/antijingoist/opendyslexic",
 		"revision": "48218028cc8bd9f4f244cd4ce4049e6c879d4d1a"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/OpenDyslexic-Bold.otf",

--- a/sources/ostrich-sans/metadata.json
+++ b/sources/ostrich-sans/metadata.json
@@ -5,8 +5,6 @@
 		"display",
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Tyler Finck",
 	"license": {
@@ -18,7 +16,6 @@
 		"repository": "https://github.com/theleagueof/ostrich-sans",
 		"revision": "a949d40d0576d12ba26e2a45e19c91fd0228c964"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/OstrichSans-Black.otf",

--- a/sources/syne-italic/metadata.json
+++ b/sources/syne-italic/metadata.json
@@ -5,8 +5,6 @@
 		"display",
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Lucas Descroix with Bonjour Monde",
 	"license": {
@@ -18,7 +16,6 @@
 		"repository": "https://gitlab.com/bonjour-monde/fonderie/syne-typeface",
 		"revision": "e536e8f1a8724bf282da74bbae410f91231ce94c"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/Syne-Italic.ttf",

--- a/sources/uncut-sans/metadata.json
+++ b/sources/uncut-sans/metadata.json
@@ -4,8 +4,6 @@
 	"classifications": [
 		"sans-serif"
 	],
-	"tags": [],
-	"languages": [],
 	"primaryScript": "Latn",
 	"designer": "Kasper Nordkvist",
 	"license": {
@@ -17,7 +15,6 @@
 		"repository": "https://github.com/kaspernordkvist/uncut_sans",
 		"revision": "b3b42467781e3bd98c68f2d70eba325196e7d9c5"
 	},
-	"declaredSubsets": [],
 	"sourceFiles": [
 		{
 			"path": "files/UncutSans-Variable.ttf",


### PR DESCRIPTION
## Overview

Updates the existing source manifests for the simplified registry contract by omitting empty tags and inferred languages, and removing the retired family-level declared subsets field.