### PR TITLE
ci: check registry sources

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,13 @@
 name: Package Verifier
-on: [pull_request, push]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
+  registry:
+    uses: fontsource/fontsource/.github/workflows/registry-check.yml@main
+
   build:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Depends on fontsource/fontsource#1217

## Overview

Runs Fontsource’s registry check for every font-files change. The reusable workflow checks out only `sources/` while retaining the history needed for provenance.